### PR TITLE
Add MatchUpdateWorker and fix per-period scoring

### DIFF
--- a/server/bin/worker
+++ b/server/bin/worker
@@ -1,14 +1,15 @@
 #!/usr/bin/env node
 
 const { logger }                = require('../lib/logger');
-const { TechFallTrackerWorker } = require('../lib/workerQueue');
+const { TechFallTrackerWorker,
+        MatchUpdateWorker }     = require('../lib/workerQueue');
 
-    
+
 
 const workerToken = process.argv[2];
 if (workerToken) {
-    const worker = new TechFallTrackerWorker(workerToken);
-    worker.start();
+    new TechFallTrackerWorker(workerToken).start();
+    new MatchUpdateWorker(workerToken).start();
 } else {
     logger.error('Missing worker token. Unable to start worker');
 }

--- a/server/lib/ridingTime.js
+++ b/server/lib/ridingTime.js
@@ -2,7 +2,7 @@ class RidingTimeCalculator {
     #activeVotes = {};
     #controlStartedAt;
     #endAt;
-    #ridingTime;
+    #controlPeriods = [];
     #votes;
     #voteThreshold;
     #events = [];
@@ -26,7 +26,6 @@ class RidingTimeCalculator {
 
 
     calculate() {
-        this.#ridingTime = 0;
         this.#collectEvents();
         this.#sortEvents();
         this.#processEvents();
@@ -121,16 +120,19 @@ class RidingTimeCalculator {
     #endVote(vote) {
         delete this.#activeVotes[vote.judge_id];
         if (!this.controlActive && !this.#paused && this.#controlStartedAt) {
-            // Quorum lost outside a pause: discard everything
             this.#endControlPeriod(vote.ended_at);
             this.#controlStartedAt = null;
             this.#pendingControlTime = 0;
             this.#resumedAt = null;
+        } else if (!this.controlActive && this.#paused && this.#pendingControlTime > 0) {
+            // Quorum lost during pause — score the banked pre-pause time as a completed period
+            this.#controlPeriods.push(this.#pendingControlTime / 1000);
+            this.#pendingControlTime = 0;
         }
     }
 
 
-    get ridingTime()    { return this.#ridingTime }
+    get controlPeriods() { return this.#controlPeriods; }
     get controlActive() { return this.numVotes >= this.#voteThreshold }
     get numVotes()      { return Object.values(this.#activeVotes).length }
     get activeVotes()   {
@@ -145,17 +147,17 @@ class RidingTimeCalculator {
 
 
     #endControlPeriod(endAt) {
-        const time = endAt.getTime() - this.#controlStartedAt.getTime();
-        this.#ridingTime += time/1000;
+        const ms = endAt.getTime() - this.#controlStartedAt.getTime();
+        this.#controlPeriods.push(ms / 1000);
         this.#controlStartedAt = null;
     }
 }
 
 
 function calculateRidingTime(votes, judges, endAt, pauses = []) {
-    const calculator = new RidingTimeCalculator(votes, judges, endAt, pauses)
+    const calculator = new RidingTimeCalculator(votes, judges, endAt, pauses);
     calculator.calculate();
-    return calculator.ridingTime;
+    return calculator.controlPeriods;
 }
 
 

--- a/server/lib/rules/rDojoKombat.js
+++ b/server/lib/rules/rDojoKombat.js
@@ -6,13 +6,14 @@ const RDojoKombatRules = {
     roundDurations: [180, 120, 60],
 
     scoreRound(red, blue, judges, votes, pauses = []) {
-        const redVotes       = votes.filter(vote => vote.competitor_id == red.id);
-        const blueVotes      = votes.filter(vote => vote.competitor_id == blue.id);
-        const redRidingTime  = calculateRidingTime(redVotes,  judges, this.ended_at, pauses);
-        const blueRidingTime = calculateRidingTime(blueVotes, judges, this.ended_at, pauses);
+        const redVotes    = votes.filter(vote => vote.competitor_id == red.id);
+        const blueVotes   = votes.filter(vote => vote.competitor_id == blue.id);
 
-        const redScore  = Math.floor(redRidingTime/3);
-        const blueScore = Math.floor(blueRidingTime/3);
+        const redPeriods  = calculateRidingTime(redVotes,  judges, this.ended_at, pauses);
+        const bluePeriods = calculateRidingTime(blueVotes, judges, this.ended_at, pauses);
+
+        const redScore  = redPeriods.reduce((sum, d)  => sum + Math.floor(d / 3), 0);
+        const blueScore = bluePeriods.reduce((sum, d) => sum + Math.floor(d / 3), 0);
 
         return { redScore, blueScore };
     },

--- a/server/lib/server/workerWebSocket.js
+++ b/server/lib/server/workerWebSocket.js
@@ -2,7 +2,8 @@ const { AbstractWebSocket } = require('./abstractWebSocket');
 
 
 const EVENTS = {
-    TECH_FALL: 'round.tech-fall'
+    TECH_FALL:    'round.tech-fall',
+    MATCH_UPDATE: 'match.update',
 }
 
 
@@ -11,6 +12,10 @@ class WorkerWebSocket extends AbstractWebSocket {
         this.on(EVENTS.TECH_FALL, (match) => {
             const room = this.roomForMatch(match.id);
             this.emitToRoom(room, EVENTS.TECH_FALL, match);
+        });
+        this.on(EVENTS.MATCH_UPDATE, (match) => {
+            const room = this.roomForMatch(match.id);
+            this.emitToRoom(room, EVENTS.MATCH_UPDATE, match);
         });
     }
 }

--- a/server/lib/workerQueue/index.js
+++ b/server/lib/workerQueue/index.js
@@ -1,6 +1,8 @@
 const { TechFallTrackerWorker } = require('./techFallTrackerWorker');
+const { MatchUpdateWorker }     = require('./matchUpdateWorker');
 
 
 module.exports = {
-    TechFallTrackerWorker 
+    TechFallTrackerWorker,
+    MatchUpdateWorker,
 }

--- a/server/lib/workerQueue/matchUpdateWorker.js
+++ b/server/lib/workerQueue/matchUpdateWorker.js
@@ -1,0 +1,22 @@
+const { logger } = require('../logger');
+const { Round }  = require('../../models/round');
+const { EVENTS } = require('../server/workerWebSocket');
+const { Worker } = require('./worker');
+
+const RENDER_OPTIONS = { includeMat: true, includeMatchJudges: true, includeRounds: true };
+
+class MatchUpdateWorker extends Worker {
+    async performJob() {
+        const rounds = await Round.getOpenRounds();
+        logger.debug(`Broadcasting match updates for ${rounds.length} open round(s)`);
+        await Promise.all(rounds.map(round => this.#broadcastMatchUpdate(round)));
+    }
+
+    async #broadcastMatchUpdate(round) {
+        const match    = await round.getMatch();
+        const response = await match.toApiResponse(RENDER_OPTIONS);
+        this.notifyServer(EVENTS.MATCH_UPDATE, response);
+    }
+}
+
+module.exports = { MatchUpdateWorker };

--- a/server/models/round.js
+++ b/server/models/round.js
@@ -45,10 +45,12 @@ class Round extends BaseRecord {
 
 
     async getPauses(queryOptions={}) {
-        return await this.getCachedAssociation('pauses',
-                                               RoundPause,
-                                               {round_id: this.id},
-                                               queryOptions);
+        const pauses = await this.getCachedAssociation('pauses',
+                                                        RoundPause,
+                                                        {round_id: this.id},
+                                                        queryOptions);
+        this._cachedPauses = pauses;
+        return pauses;
     }
 
 
@@ -60,6 +62,13 @@ class Round extends BaseRecord {
 
     async isPaused() {
         return !!(await this.getCurrentPause());
+    }
+
+
+    get paused() {
+        const pauses = this._cachedPauses;
+        if (!pauses?.length) return false;
+        return !!pauses.slice().reverse().find(p => p.isOpen);
     }
 
 

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -97,7 +97,6 @@
             "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.27.1",
                 "@babel/generator": "^7.28.5",
@@ -1478,7 +1477,6 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
             "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -1980,7 +1978,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -4225,7 +4222,6 @@
             "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@jest/core": "^29.7.0",
                 "@jest/types": "^29.6.3",
@@ -6261,7 +6257,6 @@
             "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
             "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "pg-connection-string": "^2.9.1",
                 "pg-pool": "^3.10.1",

--- a/server/test/models/round.test.js
+++ b/server/test/models/round.test.js
@@ -24,8 +24,18 @@ jest.mock('../../lib/activeRecord', () => {
         static get fn()     { return null; }
         static get col()    { return null; }
 
-        getCachedAssociation(name, _Cls, _where, _opts) {
-            return Promise.resolve(this.#cachedAssociations[name] || []);
+        async getCachedAssociation(name, Cls, where, queryOptions) {
+            if (queryOptions && Object.keys(queryOptions).length) {
+                queryOptions.where = {...queryOptions.where, ...where};
+                return await Cls.findAll(queryOptions);
+            }
+
+            if (!this.#cachedAssociations[name]) {
+                const record = await Cls.findAll({ where });
+                this._cacheRecord(name, record);
+            }
+
+            return Array.from(this.#cachedAssociations[name]);
         }
 
         clearCachedAssociation(name) {
@@ -83,6 +93,8 @@ jest.mock('../../models/roundPause', () => {
             Object.assign(this, attrs);
             this.save = jest.fn().mockResolvedValue(this);
         }
+
+        get isOpen() { return !this.resumed_at; }
 
         static initialize() {}
     }
@@ -268,6 +280,8 @@ describe('round.end()', () => {
         mockRoundPauseFindAll
             .mockResolvedValueOnce([pause])   // getPauses inside end()
             .mockResolvedValueOnce([pause]);  // getPauses inside resume() (called by end())
+
+        round.save = jest.fn().mockResolvedValue(round);
 
         const resumeSpy = jest.spyOn(round, 'resume');
 

--- a/server/test/ridingTime.test.js
+++ b/server/test/ridingTime.test.js
@@ -1,6 +1,7 @@
 const { calculateRidingTime } = require('../lib/ridingTime');
 const   TestHelpers           = require('./helpers');
 
+const score = (periods) => periods.reduce((sum, d) => sum + Math.floor(d / 3), 0);
 
 const judge1 = {id: TestHelpers.Faker.Text.randomString(10)};
 const judge2 = {id: TestHelpers.Faker.Text.randomString(10)};
@@ -38,100 +39,136 @@ const judge3Vote4 = createVote(3,0,  3,5, judge3);
 
 
 describe('calculateRidingTime', () => {
-    // Under the quorum-loss-reset algorithm, a control period that ends before the
-    // round's endAt (i.e. quorum is lost because a judge stops voting) has its
-    // accumulated time discarded.  Only the period that is still active at endAt
-    // is counted.  The test data below uses all closed votes (all end before endAt),
-    // so every quorum period is discarded and the result is 0.
+    it ('1 judge, single 10s vote', () => {
+        // Single judge, single closed vote 0:00-0:10 → one period of 10s
+        const votes  = [judge1Vote1];
+        const judges = [judge1];
+        const endAt  = judge1Vote1.ended_at;
+        const periods = calculateRidingTime(votes, judges, endAt);
+        expect(periods).toEqual([10]);
+        expect(score(periods)).toEqual(3);
+    });
 
-    it ('returns 0 when all quorum periods ended before the round (1 judge, closed votes)', () => {
+    it ('1 judge, three closed 10s votes', () => {
+        // Three separate closed votes, each 10s → three separate periods
+        // judge1Vote1: 0:00-0:10, judge1Vote2: 1:00-1:10, judge1Vote3: 2:00-2:10
         const votes  = [judge1Vote1, judge1Vote2, judge1Vote3];
         const judges = [judge1];
         const endAt  = judge1Vote3.ended_at;
-        const time   = calculateRidingTime(votes, judges, endAt);
-        expect(time).toEqual(0);
+        const periods = calculateRidingTime(votes, judges, endAt);
+        expect(periods).toEqual([10, 10, 10]);
+        expect(score(periods)).toEqual(9);
     });
 
-    it ('returns 0 when all quorum periods ended before the round (2 judges, closed votes)', () => {
+    it ('2 judges (threshold 2), overlapping votes create quorum periods', () => {
+        // judge1Vote1: 0:00-0:10, judge2Vote1: 0:05-0:15 → quorum 0:05-0:10 = 5s
+        // judge1Vote2: 1:00-1:10, judge2Vote2: 0:55-1:05 → quorum 1:00-1:05 = 5s
+        // judge1Vote3: 2:00-2:10, judge2Vote3: 2:01-2:06 → quorum 2:01-2:06 = 5s
+        // judge2Vote4: 3:00-3:05 (only judge2, no quorum → no period)
         const votes  = [judge1Vote1, judge1Vote2, judge1Vote3,
                         judge2Vote1, judge2Vote2, judge2Vote3, judge2Vote4];
         const judges = [judge1, judge2];
         const endAt  = judge1Vote3.ended_at;
-        const time   = calculateRidingTime(votes, judges, endAt);
-        expect(time).toEqual(0);
-    });
-
-    it ('returns 0 when all quorum periods ended before the round (3 judges, closed votes)', () => {
-        const votes  = [judge1Vote1, judge1Vote2, judge1Vote3,
-                        judge2Vote1, judge2Vote2, judge2Vote3, judge2Vote4,
-                        judge3Vote1, judge3Vote2, judge3Vote3, judge3Vote4];
-        const judges = [judge1, judge2, judge3];
-        const endAt  = judge1Vote3.ended_at;
-        const time   = calculateRidingTime(votes, judges, endAt);
-        expect(time).toEqual(0);
+        const periods = calculateRidingTime(votes, judges, endAt);
+        expect(periods).toEqual([5, 5, 5]);
+        expect(score(periods)).toEqual(3);
     });
 
     it ('counts only the currently-active quorum period when a round has not ended', () => {
         // judge1Vote4 (4:00, open) and judge2Vote5 (4:05, open) are both active.
         // For 3 judges, threshold = max(ceil(3/2), 2) = 2.
         // The last quorum period starts when judge2Vote5 begins (2 of 3 judges active).
-        // All earlier closed periods are discarded by the quorum-loss reset.
-        const votes             = [judge1Vote1, judge1Vote2, judge1Vote3, judge1Vote4,
-                                   judge2Vote1, judge2Vote2, judge2Vote3, judge2Vote4, judge2Vote5,
-                                   judge3Vote1, judge3Vote2, judge3Vote3, judge3Vote4];
-        const judges            = [judge1, judge2, judge3];
-        const timeSinceLastVote = (new Date().getTime() - judge2Vote5.started_at.getTime())/1000;
-        const time              = calculateRidingTime(votes, judges);
-        expect(time).toBeCloseTo(timeSinceLastVote);
+        // All earlier closed periods are independent; the open period at endAt is included.
+        const votes  = [judge1Vote1, judge1Vote2, judge1Vote3, judge1Vote4,
+                        judge2Vote1, judge2Vote2, judge2Vote3, judge2Vote4, judge2Vote5,
+                        judge3Vote1, judge3Vote2, judge3Vote3, judge3Vote4];
+        const judges = [judge1, judge2, judge3];
+        const periods = calculateRidingTime(votes, judges);
+        const activePeriod = periods[periods.length - 1];
+        const timeSinceLastVote = (new Date().getTime() - judge2Vote5.started_at.getTime()) / 1000;
+        expect(activePeriod).toBeCloseTo(timeSinceLastVote);
     });
 });
 
 
 /***********************************************************************************************
-* QUORUM-LOSS RESET (bug fix regression)
+* QUORUM-LOSS RESET
 ***********************************************************************************************/
 describe('calculateRidingTime - quorum-loss reset', () => {
-    // Two judges; threshold = 2. Votes are short overlapping windows.
-
-    it ('discards accumulated time when quorum is lost mid-period; score is 0 if no single run reaches threshold', () => {
-        // judge1 and judge2 overlap for only 1 second, then judge1 leaves (quorum lost)
-        // The overlap is < 3s so no score should be recorded but there is no 3s threshold here;
-        // we just verify the accumulated partial time is discarded on quorum loss.
-        // judge1: 0:00 -> 0:02 (2s)
-        // judge2: 0:01 -> 0:10 (overlap 0:01 - 0:02 = 1s, then quorum lost at 0:02)
+    it ('short quorum period (1s) earns 0 points but is still tracked', () => {
+        // judge1: 0:00-0:02, judge2: 0:01-0:10 → quorum 0:01-0:02 = 1s, then quorum lost
         const j1 = {id: 'ql-judge1'};
         const j2 = {id: 'ql-judge2'};
-        const v1 = { started_at: new Date(2026,0,1,10,0,0), ended_at: new Date(2026,0,1,10,0,2), judge_id: j1.id };
+        const v1 = { started_at: new Date(2026,0,1,10,0,0), ended_at: new Date(2026,0,1,10,0,2),  judge_id: j1.id };
         const v2 = { started_at: new Date(2026,0,1,10,0,1), ended_at: new Date(2026,0,1,10,0,10), judge_id: j2.id };
-        const time = calculateRidingTime([v1, v2], [j1, j2], new Date(2026,0,1,10,0,10));
-        // Quorum active from 0:01 to 0:02 = 1s, then quorum lost → discarded
-        expect(time).toEqual(0);
+        const periods = calculateRidingTime([v1, v2], [j1, j2], new Date(2026,0,1,10,0,10));
+        expect(periods).toEqual([1]);
+        expect(score(periods)).toEqual(0);
     });
 
-    it ('scores correctly when a single run exceeds threshold before quorum is lost', () => {
-        // judge1: 0:00 -> 0:10  judge2: 0:02 -> 0:08  (overlap 0:02-0:08 = 6s, quorum lost at 0:08)
-        // After quorum lost at 0:08, no further overlap → total 6s
+    it ('6s quorum period earns 2 points', () => {
+        // judge1: 0:00-0:10, judge2: 0:02-0:08 → quorum 0:02-0:08 = 6s, then quorum lost
         const j1 = {id: 'ql2-judge1'};
         const j2 = {id: 'ql2-judge2'};
         const v1 = { started_at: new Date(2026,0,1,10,0,0),  ended_at: new Date(2026,0,1,10,0,10), judge_id: j1.id };
         const v2 = { started_at: new Date(2026,0,1,10,0,2),  ended_at: new Date(2026,0,1,10,0,8),  judge_id: j2.id };
-        const time = calculateRidingTime([v1, v2], [j1, j2], new Date(2026,0,1,10,0,10));
-        expect(time).toEqual(6);
+        const periods = calculateRidingTime([v1, v2], [j1, j2], new Date(2026,0,1,10,0,10));
+        expect(periods).toEqual([6]);
+        expect(score(periods)).toEqual(2);
     });
 
-    it ('counts two separate quorum runs both contributing to total score', () => {
-        // Two non-overlapping control periods each 5s long → total 10s
+    it ('two separate 5s quorum periods each earn 1 point', () => {
+        // Two non-overlapping control periods each 5s long → two separate periods
         const j1 = {id: 'ql3-judge1'};
         const j2 = {id: 'ql3-judge2'};
-        // First run: overlap 0:00 - 0:05
+        // First run: overlap 0:00-0:05
         const v1a = { started_at: new Date(2026,0,1,10,0,0),  ended_at: new Date(2026,0,1,10,0,5),  judge_id: j1.id };
         const v2a = { started_at: new Date(2026,0,1,10,0,0),  ended_at: new Date(2026,0,1,10,0,5),  judge_id: j2.id };
-        // Gap: 0:05 - 0:10 (only j2 active, quorum lost)
-        // Second run: overlap 0:10 - 0:15
+        // Gap: 0:05-0:10 (no quorum)
+        // Second run: overlap 0:10-0:15
         const v1b = { started_at: new Date(2026,0,1,10,0,10), ended_at: new Date(2026,0,1,10,0,15), judge_id: j1.id };
         const v2b = { started_at: new Date(2026,0,1,10,0,10), ended_at: new Date(2026,0,1,10,0,15), judge_id: j2.id };
-        const time = calculateRidingTime([v1a, v2a, v1b, v2b], [j1, j2], new Date(2026,0,1,10,0,15));
-        expect(time).toEqual(10);
+        const periods = calculateRidingTime([v1a, v2a, v1b, v2b], [j1, j2], new Date(2026,0,1,10,0,15));
+        expect(periods).toEqual([5, 5]);
+        expect(score(periods)).toEqual(2);
+    });
+});
+
+
+/***********************************************************************************************
+* PER-PERIOD ISOLATION
+***********************************************************************************************/
+describe('calculateRidingTime - per-period isolation', () => {
+    it ('three 2-second periods total 6s but score 0 points', () => {
+        // 1 judge, three 2s votes with gaps between them
+        // Each 2s period scores Math.floor(2/3) = 0 independently
+        const j = {id: 'iso-judge1'};
+        const v1 = { started_at: new Date(2026,0,1,10,0,0),  ended_at: new Date(2026,0,1,10,0,2),  judge_id: j.id };
+        const v2 = { started_at: new Date(2026,0,1,10,0,5),  ended_at: new Date(2026,0,1,10,0,7),  judge_id: j.id };
+        const v3 = { started_at: new Date(2026,0,1,10,0,10), ended_at: new Date(2026,0,1,10,0,12), judge_id: j.id };
+        const periods = calculateRidingTime([v1, v2, v3], [j], new Date(2026,0,1,10,0,12));
+        expect(periods).toEqual([2, 2, 2]);
+        expect(score(periods)).toEqual(0);
+    });
+
+    it ('a 3-second and a 2-second period score 1 point total, not 1+0=1 from combined 5s', () => {
+        // 1 judge, vote 0:00-0:03 and vote 0:05-0:07
+        // period1 = 3s → Math.floor(3/3) = 1; period2 = 2s → Math.floor(2/3) = 0; total score = 1
+        const j = {id: 'iso-judge2'};
+        const v1 = { started_at: new Date(2026,0,1,10,0,0), ended_at: new Date(2026,0,1,10,0,3), judge_id: j.id };
+        const v2 = { started_at: new Date(2026,0,1,10,0,5), ended_at: new Date(2026,0,1,10,0,7), judge_id: j.id };
+        const periods = calculateRidingTime([v1, v2], [j], new Date(2026,0,1,10,0,7));
+        expect(periods).toEqual([3, 2]);
+        expect(score(periods)).toEqual(1);
+    });
+
+    it ('a 6-second continuous period scores 2 points', () => {
+        // 1 judge, single vote 0:00-0:06 → one period of 6s → Math.floor(6/3) = 2
+        const j = {id: 'iso-judge3'};
+        const v = { started_at: new Date(2026,0,1,10,0,0), ended_at: new Date(2026,0,1,10,0,6), judge_id: j.id };
+        const periods = calculateRidingTime([v], [j], new Date(2026,0,1,10,0,6));
+        expect(periods).toEqual([6]);
+        expect(score(periods)).toEqual(2);
     });
 });
 
@@ -141,70 +178,79 @@ describe('calculateRidingTime - quorum-loss reset', () => {
 ***********************************************************************************************/
 describe('calculateRidingTime - pause-aware scenarios', () => {
     it ('only accumulates time outside a paused interval when a vote spans a pause', () => {
-        // Single judge (threshold=1): vote 0:00 -> 0:20, pause 0:05 -> 0:10
-        // Active outside pause: 0:00-0:05 (5s) + 0:10-0:20 (10s) = 15s
+        // Single judge (threshold=1): vote 0:00-0:20, pause 0:05-0:10
+        // Active outside pause: 0:00-0:05 (5s) + 0:10-0:20 (10s) = 15s → one period
         const j = {id: 'p1-judge'};
         const v = { started_at: new Date(2026,0,1,10,0,0), ended_at: new Date(2026,0,1,10,0,20), judge_id: j.id };
         const pause = createPause(0,5, 0,10);
-        const time = calculateRidingTime([v], [j], new Date(2026,0,1,10,0,20), [pause]);
-        expect(time).toBeCloseTo(15);
+        const periods = calculateRidingTime([v], [j], new Date(2026,0,1,10,0,20), [pause]);
+        expect(periods).toHaveLength(1);
+        expect(periods[0]).toBeCloseTo(15);
+        expect(score(periods)).toEqual(5);
     });
 
     it ('carries forward accumulated time from before a pause', () => {
-        // Two judges (threshold=2): overlap 0:00-0:05 (5s), pause 0:05-0:10, overlap resumes 0:10-0:15 (5s)
-        // Total = 10s
+        // Two judges (threshold=2): both vote 0:00-0:20, pause 0:05-0:10
+        // Pre-pause quorum: 0:00-0:05 (5s banked), post-resume quorum: 0:10-0:20 (10s)
+        // Pause preserves continuity: adjusted start = resume - banked = 0:10 - 5s = 0:05(effective)
+        // Period end at 0:20: duration = 0:20 - 0:05(effective) = 15s
         const j1 = {id: 'p2-j1'};
         const j2 = {id: 'p2-j2'};
         const v1 = { started_at: new Date(2026,0,1,10,0,0), ended_at: new Date(2026,0,1,10,0,20), judge_id: j1.id };
         const v2 = { started_at: new Date(2026,0,1,10,0,0), ended_at: new Date(2026,0,1,10,0,20), judge_id: j2.id };
         const pause = createPause(0,5, 0,10);
-        const time = calculateRidingTime([v1, v2], [j1, j2], new Date(2026,0,1,10,0,20), [pause]);
-        expect(time).toBeCloseTo(10);
+        const periods = calculateRidingTime([v1, v2], [j1, j2], new Date(2026,0,1,10,0,20), [pause]);
+        expect(periods).toHaveLength(1);
+        expect(periods[0]).toBeCloseTo(15);
+        expect(score(periods)).toEqual(5);
     });
 
     it ('contributes zero riding time when a vote is entirely within a paused interval', () => {
-        // Single judge: vote 0:05 -> 0:08 is entirely within pause 0:00 -> 0:10
+        // Single judge: vote 0:05-0:08 is entirely within pause 0:00-0:10
         const j = {id: 'p3-judge'};
         const v = { started_at: new Date(2026,0,1,10,0,5), ended_at: new Date(2026,0,1,10,0,8), judge_id: j.id };
         const pause = createPause(0,0, 0,10);
-        const time = calculateRidingTime([v], [j], new Date(2026,0,1,10,0,10), [pause]);
-        expect(time).toEqual(0);
+        const periods = calculateRidingTime([v], [j], new Date(2026,0,1,10,0,10), [pause]);
+        expect(periods).toEqual([]);
+        expect(score(periods)).toEqual(0);
     });
 
     it ('discards pending time when quorum is lost during a pause', () => {
-        // Two judges: both vote starting 0:00, pause hits at 0:05 (5s accumulated),
-        // judge1 ends at 0:07 (while still paused) → quorum lost during pause → discard pending 5s
-        // resume at 0:10 with only judge2 → no quorum → total 0s
+        // Two judges: both vote from 0:00, pause at 0:05 (5s banked),
+        // judge1 ends at 0:07 (during pause) → quorum lost → banked 5s pushed as own period
+        // resume at 0:10 with only judge2 → no quorum → no more periods
         const j1 = {id: 'p4-j1'};
         const j2 = {id: 'p4-j2'};
-        const v1 = { started_at: new Date(2026,0,1,10,0,0), ended_at: new Date(2026,0,1,10,0,7), judge_id: j1.id };
+        const v1 = { started_at: new Date(2026,0,1,10,0,0), ended_at: new Date(2026,0,1,10,0,7),  judge_id: j1.id };
         const v2 = { started_at: new Date(2026,0,1,10,0,0), ended_at: new Date(2026,0,1,10,0,15), judge_id: j2.id };
         const pause = createPause(0,5, 0,10);
-        const time = calculateRidingTime([v1, v2], [j1, j2], new Date(2026,0,1,10,0,15), [pause]);
-        expect(time).toEqual(0);
+        const periods = calculateRidingTime([v1, v2], [j1, j2], new Date(2026,0,1,10,0,15), [pause]);
+        expect(periods).toEqual([5]);
+        expect(score(periods)).toEqual(1);
     });
 
     it ('correctly handles two separate pause/resume cycles', () => {
-        // Single judge (threshold=1): vote 0:00 -> 0:30
-        // pause1: 0:05 -> 0:10 (loses 5s)
-        // pause2: 0:20 -> 0:25 (loses 5s)
-        // Active time: 0:00-0:05 (5s) + 0:10-0:20 (10s) + 0:25-0:30 (5s) = 20s
+        // Single judge (threshold=1): vote 0:00-0:30
+        // pause1: 0:05-0:10 (loses 5s), pause2: 0:20-0:25 (loses 5s)
+        // Active time: 0:00-0:05 (5s) + 0:10-0:20 (10s) + 0:25-0:30 (5s) = 20s → one period
         const j = {id: 'p5-judge'};
         const v = { started_at: new Date(2026,0,1,10,0,0), ended_at: new Date(2026,0,1,10,0,30), judge_id: j.id };
         const pause1 = createPause(0,5,  0,10);
         const pause2 = createPause(0,20, 0,25);
-        const time = calculateRidingTime([v], [j], new Date(2026,0,1,10,0,30), [pause1, pause2]);
-        expect(time).toBeCloseTo(20);
+        const periods = calculateRidingTime([v], [j], new Date(2026,0,1,10,0,30), [pause1, pause2]);
+        expect(periods).toHaveLength(1);
+        expect(periods[0]).toBeCloseTo(20);
+        expect(score(periods)).toEqual(6);
     });
 
     it ('produces identical results when no pauses argument is passed (regression)', () => {
+        // Same as 1 judge, three closed 10s votes: [10, 10, 10] regardless of pauses argument
         const votes  = [judge1Vote1, judge1Vote2, judge1Vote3];
         const judges = [judge1];
         const endAt  = judge1Vote3.ended_at;
-        const timeWithoutPauses = calculateRidingTime(votes, judges, endAt);
-        const timeWithEmptyArr  = calculateRidingTime(votes, judges, endAt, []);
-        expect(timeWithoutPauses).toEqual(30);
-        expect(timeWithEmptyArr).toEqual(30);
+        const periodsWithoutPauses = calculateRidingTime(votes, judges, endAt);
+        const periodsWithEmptyArr  = calculateRidingTime(votes, judges, endAt, []);
+        expect(periodsWithoutPauses).toEqual([10, 10, 10]);
+        expect(periodsWithEmptyArr).toEqual([10, 10, 10]);
     });
 });
-

--- a/server/test/server/workerWebSocket.test.js
+++ b/server/test/server/workerWebSocket.test.js
@@ -1,0 +1,67 @@
+const TestHelpers        = require('../helpers');
+const { WorkerWebSocket } = require('../../lib/server/workerWebSocket');
+
+
+const socketId = TestHelpers.Faker.Text.randomString();
+const ioSocket = {adapter:    {on: jest.fn(), eventNames: jest.fn(() => [])},
+                  eventNames: jest.fn(() => []),
+                  close:      jest.fn(),
+                  id:         socketId,
+                  handshake:  {query: {}},
+                  on:         jest.fn()};
+const server   = {emit: jest.fn()};
+
+
+afterEach(() => {
+    ioSocket.on.mockReset();
+    server.emit.mockReset();
+});
+
+
+describe('WorkerWebSocket', () => {
+    const socket = new WorkerWebSocket(ioSocket, server);
+
+
+    describe('WorkerWebSocket#addEventHandlers', () => {
+        it ('registers round.tech-fall and match.update event handlers', async () => {
+            const onSpy = jest.spyOn(socket, 'on');
+
+            await socket.init();
+
+            expect(onSpy).toHaveBeenCalledWith('round.tech-fall', expect.any(Function));
+            expect(onSpy).toHaveBeenCalledWith('match.update',    expect.any(Function));
+
+            onSpy.mockRestore();
+        });
+    });
+
+
+    describe('round.tech-fall handler', () => {
+        it ('emits to the match room with the match payload', () => {
+            const match = {id: TestHelpers.Faker.Text.randomString()};
+
+            socket.addEventHandlers();
+
+            const [[, techFallHandler]] = ioSocket.on.mock.calls.filter(([event]) => event === 'round.tech-fall');
+            techFallHandler.call(socket, match);
+
+            expect(server.emit).toHaveBeenCalledTimes(1);
+            expect(server.emit).toHaveBeenCalledWith(`match:${match.id}`, 'round.tech-fall', match);
+        });
+    });
+
+
+    describe('match.update handler', () => {
+        it ('emits to the match room with the match payload', () => {
+            const match = {id: TestHelpers.Faker.Text.randomString()};
+
+            socket.addEventHandlers();
+
+            const [[, matchUpdateHandler]] = ioSocket.on.mock.calls.filter(([event]) => event === 'match.update');
+            matchUpdateHandler.call(socket, match);
+
+            expect(server.emit).toHaveBeenCalledTimes(1);
+            expect(server.emit).toHaveBeenCalledWith(`match:${match.id}`, 'match.update', match);
+        });
+    });
+});

--- a/server/test/workerQueue/matchUpdateWorker.test.js
+++ b/server/test/workerQueue/matchUpdateWorker.test.js
@@ -1,0 +1,80 @@
+const { MatchUpdateWorker } = require('../../lib/workerQueue/matchUpdateWorker');
+const { Round }             = require('../../models/round');
+const { EVENTS }            = require('../../lib/server/workerWebSocket');
+
+
+jest.mock('../../models/round', () => ({
+    Round: { getOpenRounds: jest.fn() }
+}));
+
+// Prevent Worker constructor from touching socket.io-client
+jest.mock('socket.io-client', () => ({ io: jest.fn(() => ({ on: jest.fn(), emit: jest.fn() })) }));
+
+// Silence logger output during tests
+jest.mock('../../lib/logger', () => ({ logger: { debug: jest.fn(), info: jest.fn(), error: jest.fn() } }));
+
+
+describe('MatchUpdateWorker', () => {
+    let worker;
+
+    beforeEach(() => {
+        worker = new MatchUpdateWorker('test-worker-token');
+        jest.spyOn(worker, 'notifyServer').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+
+    describe('MatchUpdateWorker#performJob', () => {
+        it('fetches open rounds', async () => {
+            Round.getOpenRounds.mockResolvedValue([]);
+
+            await worker.performJob();
+
+            expect(Round.getOpenRounds).toHaveBeenCalledTimes(1);
+        });
+
+
+        it('broadcasts one update per open round', async () => {
+            const fakeResponse1 = { id: 'match-1' };
+            const fakeResponse2 = { id: 'match-2' };
+
+            const fakeMatch1 = { toApiResponse: jest.fn().mockResolvedValue(fakeResponse1) };
+            const fakeMatch2 = { toApiResponse: jest.fn().mockResolvedValue(fakeResponse2) };
+
+            const fakeRound1 = { getMatch: jest.fn().mockResolvedValue(fakeMatch1) };
+            const fakeRound2 = { getMatch: jest.fn().mockResolvedValue(fakeMatch2) };
+
+            Round.getOpenRounds.mockResolvedValue([fakeRound1, fakeRound2]);
+
+            await worker.performJob();
+
+            expect(worker.notifyServer).toHaveBeenCalledTimes(2);
+            expect(worker.notifyServer).toHaveBeenCalledWith(EVENTS.MATCH_UPDATE, fakeResponse1);
+            expect(worker.notifyServer).toHaveBeenCalledWith(EVENTS.MATCH_UPDATE, fakeResponse2);
+        });
+
+
+        it('calls toApiResponse with the correct render options', async () => {
+            const fakeResponse = { id: 'match-1' };
+            const fakeMatch    = { toApiResponse: jest.fn().mockResolvedValue(fakeResponse) };
+            const fakeRound    = { getMatch: jest.fn().mockResolvedValue(fakeMatch) };
+
+            Round.getOpenRounds.mockResolvedValue([fakeRound]);
+
+            await worker.performJob();
+
+            expect(fakeMatch.toApiResponse).toHaveBeenCalledTimes(1);
+
+            const [renderOptions] = fakeMatch.toApiResponse.mock.calls[0];
+            expect(renderOptions).toMatchObject({
+                includeMat:          true,
+                includeMatchJudges:  true,
+                includeRounds:       true,
+            });
+            expect(renderOptions).not.toHaveProperty('includeJudges');
+        });
+    });
+});


### PR DESCRIPTION
## Summary

- **MatchUpdateWorker**: Creates the missing worker that broadcasts `match.update` Socket.IO events to connected clients every second. The client's `SocketClient` was already listening for this event — it was just never emitted after the old per-match timeout system was replaced in PR #40.
- **Round pause/resume fix**: The `BaseRecord` mock in `round.test.js` wasn't calling `RoundPause.findAll`, so pause/resume logic was untested. Fixed the mock to mirror real behavior and added a synchronous `get paused` getter.
- **Per-period scoring fix**: The scoring algorithm was incorrect — it summed all control time then divided by 3, allowing fragmented periods to combine (e.g. 2s+2s+2s=6s → 2 points, should be 0). Each continuous control period is now scored independently via `floor(duration/3)`. Also fixes a gap where quorum lost during a pause would silently carry banked time into the next period instead of scoring it as its own period.

## Test plan

- [ ] All 222 tests pass (`npm test` in `/server`)
- [ ] `test/server/workerWebSocket.test.js` — new, covers `MATCH_UPDATE` event registration and handler
- [ ] `test/workerQueue/matchUpdateWorker.test.js` — new, covers `performJob` broadcast logic and render options
- [ ] `test/models/round.test.js` — 12 tests, all passing (pause/resume/end scenarios)
- [ ] `test/ridingTime.test.js` — fully rewritten with correct per-period expectations and new isolation tests