### PR TITLE
UI polish: tablet layout, typography, emoji results, keyboard nav

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,9 +177,9 @@ Express Route → Controller → Authenticate → Authorize → Execute → Rend
 
 5. **Room-Based Broadcasting**: WebSocket rooms keep server scalable; all interested clients receive updates atomically
 
-6. **Match Extensions in `models_ext.kt`**: All winner/score derivation from `Match` belongs in `/app/app/src/commonMain/kotlin/dev/jvmname/accord/network/models_ext.kt`, not inlined in presenters. Key extensions: `Match.winner(roundIndex)`, `Match.winnerCompetitor`, `Match.roundScore()`, `Match.toMatchResult()`.
+6. **Match Extensions in `models_ext.kt`**: All winner/score derivation from `Match` belongs in `/app/app/src/commonMain/kotlin/dev/jvmname/accord/network/models_ext.kt`, not inlined in presenters. Key extensions: `Match.winner(roundIndex)`, `Match.winnerCompetitor`, `Match.roundScore()`, `Match.toMatchResult()`. `toMatchResult()` always returns a non-null `MatchResult` for any ended match — do NOT add a `winner ?: return null` guard; a null winner on an ended match is a valid draw.
 
-7. **`MatchResult` is shared across screens**: Defined in `JudgeSessionScreen.kt` but imported by `MasterSessionScreen.kt` as well. `winner` field is `Pair<User, Competitor>` (not just `Competitor`).
+7. **`MatchResult` is shared across screens**: Defined in `JudgeSessionScreen.kt` but imported by `MasterSessionScreen.kt` as well. Has `winConditions: String` and `roundWinners: List<Competitor>`. Empty `roundWinners` means all rounds were tied (draw); `toText()` handles this case.
 
 8. **Judge vs Master role separation**: Judges only vote on control time — they do NOT handle meta-round actions (submission, stoppage, manual score edits are master-only). `JudgeSessionEvent.EndRound` is a simple `data object` that ends the round with no params. All structured end-round actions (submission name, who submitted/stopped, stoppage vs submission choice) belong exclusively in the master session.
 

--- a/app/app/src/androidMain/kotlin/dev/jvmname/accord/ui/util.android.kt
+++ b/app/app/src/androidMain/kotlin/dev/jvmname/accord/ui/util.android.kt
@@ -1,0 +1,18 @@
+package dev.jvmname.accord.ui
+
+import android.content.pm.ActivityInfo
+import androidx.activity.compose.LocalActivity
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+
+@Composable
+actual fun LockLandscape() {
+    val activity = LocalActivity.current ?: return
+    val original = activity.requestedOrientation
+    DisposableEffect(original) {
+        activity.requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_USER_LANDSCAPE
+        onDispose {
+            activity.requestedOrientation = original
+        }
+    }
+}

--- a/app/app/src/commonMain/kotlin/dev/jvmname/accord/domain/session/SoloMatchSession.kt
+++ b/app/app/src/commonMain/kotlin/dev/jvmname/accord/domain/session/SoloMatchSession.kt
@@ -20,7 +20,17 @@ import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.dropWhile
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.runningFold
+import kotlinx.coroutines.flow.scan
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlin.concurrent.atomics.AtomicReference
 import kotlin.time.Duration
@@ -190,7 +200,7 @@ class SoloMatchSession(
         timer.resume()
     }
 
-    override fun endRound(winner: Competitor?, submission: String?, stoppage: Boolean) {
+    override fun endRound(winner: Competitor?, stoppage: Boolean?) {
         timer.cancel()
 
         _roundEvent.update {

--- a/app/app/src/commonMain/kotlin/dev/jvmname/accord/network/models_ext.kt
+++ b/app/app/src/commonMain/kotlin/dev/jvmname/accord/network/models_ext.kt
@@ -27,11 +27,6 @@ fun Mat.merge(other: Mat): Mat = Mat(
 )
 
 /**
- * Returns a new [Match] with fields from [other] used as fallback for absent optional associations.
- * Some endpoints (e.g. pause/resume) omit `judges` because they pass `includeJudges` instead of
- * `includeMatchJudges` — merge preserves the previously cached value in that case.
- */
-/**
  * Returns the [Competitor] who won the round at [roundIndex], or null if the round has no winner.
  */
 fun Match.winner(roundIndex: Int): Competitor? = when (rounds[roundIndex].result.winner?.id) {
@@ -55,6 +50,11 @@ fun Match.roundScore(): Map<Competitor, Int> = mapOf(
     Competitor.BLUE to rounds.count { it.result.winner?.id == blue.id },
 )
 
+/**
+ * Returns a new [Match] with fields from [other] used as fallback for absent optional associations.
+ * Some endpoints (e.g. pause/resume) omit `judges` because they pass `includeJudges` instead of
+ * `includeMatchJudges` — merge preserves the previously cached value in that case.
+ */
 fun Match.merge(other: Match): Match = Match(
     id = id,
     creatorId = creatorId,
@@ -84,11 +84,12 @@ fun Match.toMatchResult(): MatchResult? {
     val scores = roundScore()
     val loser = if (winnerC == Competitor.RED) Competitor.BLUE else Competitor.RED
     return MatchResult(
-        winner = winner to winnerC,
-        winnerScore = scores[winnerC] ?: 0,
-        loserScore = scores[loser] ?: 0,
+//        winner = winner to winnerC,
+//        winnerScore = scores[winnerC] ?: 0,
+//        loserScore = scores[loser] ?: 0,
         winConditions = rounds
             .filter { it.endedAt != null && it.result.winner == winner && it.result.method.type != null }
-            .joinToString { it.result.method.type!!.toHumanString }
+            .joinToString { it.result.method.type!!.toHumanString },
+        roundWinners = rounds.indices.mapNotNull { winner(it) }
     )
 }

--- a/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/common/CompetitorEditText.kt
+++ b/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/common/CompetitorEditText.kt
@@ -21,6 +21,7 @@ fun CompetitorEditText(
     state: TextFieldState,
     imeAction: ImeAction = ImeAction.Next,
     isError: Boolean = false,
+    onKeyboardAction: (() -> Unit)? = null,
 ) {
     val (focusedBorder, unfocusedBorder, labelColor) = when (competitor) {
         Competitor.RED -> Triple(Color(0xFFD32F2F), Color(0xFFEF9A9A), Color.Red)
@@ -38,6 +39,7 @@ fun CompetitorEditText(
             capitalization = KeyboardCapitalization.Words,
             imeAction = imeAction,
         ),
+        onKeyboardAction = { onKeyboardAction?.invoke() },
         colors = OutlinedTextFieldDefaults.colors(
             focusedBorderColor = focusedBorder,
             unfocusedBorderColor = unfocusedBorder,

--- a/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/common/IconTextButton.kt
+++ b/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/common/IconTextButton.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import dev.jvmname.accord.ui.theme.AccordTheme
 import kotlinx.coroutines.launch
 
@@ -66,7 +67,7 @@ fun IconTextButton(
         }
         Text(
             text,
-            style = MaterialTheme.typography.bodyLarge,
+            style = MaterialTheme.typography.bodyLarge.copy(fontSize = 22.sp),
             modifier = Modifier.padding(start = 6.dp)
         )
     }

--- a/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/create/mat/CreateMatMatchContent.kt
+++ b/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/create/mat/CreateMatMatchContent.kt
@@ -72,15 +72,12 @@ fun CreateMatMatchContent(state: CreateMatMatchState, modifier: Modifier) {
                 .padding(vertical = 32.dp, horizontal = 16.dp),
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            val masterNameState = rememberTextFieldState()
             val matNameState = rememberTextFieldState()
             val redNameState = rememberTextFieldState()
             val blueNameState = rememberTextFieldState()
-            var judgeCount by remember { mutableIntStateOf(1) }
-            var isJudging by remember { mutableStateOf(false) }
+            var judgeCount by remember { mutableIntStateOf(3) }
             var hasAttemptedSubmit by remember { mutableStateOf(false) }
 
-            val masterNameError = hasAttemptedSubmit && masterNameState.text.isBlank()
             val matNameError = hasAttemptedSubmit && matNameState.text.isBlank()
             val redNameError = hasAttemptedSubmit && redNameState.text.isBlank()
             val blueNameError = hasAttemptedSubmit && blueNameState.text.isBlank()
@@ -88,22 +85,6 @@ fun CreateMatMatchContent(state: CreateMatMatchState, modifier: Modifier) {
             Text("Mat Info", style = AccordTypography.titleLarge)
 
             Spacer(Modifier.height(16.dp))
-
-            OutlinedTextField(
-                masterNameState,
-                modifier = Modifier.fillMaxWidth(),
-                placeholder = { Text("Jane Smith") },
-                label = { Text("Your Name *") },
-                isError = masterNameError,
-                supportingText = if (masterNameError) {
-                    { Text("Required") }
-                } else null,
-                lineLimits = TextFieldLineLimits.SingleLine,
-                keyboardOptions = KeyboardOptions.Default.copy(
-                    capitalization = KeyboardCapitalization.Words,
-                    imeAction = ImeAction.Next,
-                ),
-            )
 
             Spacer(Modifier.height(16.dp))
 
@@ -175,17 +156,13 @@ fun CreateMatMatchContent(state: CreateMatMatchState, modifier: Modifier) {
                 },
                 onClick = {
                     hasAttemptedSubmit = true
-                    if (masterNameState.text.isBlank() || matNameState.text.isBlank() ||
-                        redNameState.text.isBlank() || blueNameState.text.isBlank()
-                    ) return@Button
+                    if (matNameState.text.isBlank() || redNameState.text.isBlank() || blueNameState.text.isBlank()) return@Button
                     state.eventSink(
                         CreateMatMatchEvent.CreateMat(
-                            masterName = masterNameState.text.toString(),
                             matName = matNameState.text.toString(),
                             judgeCount = judgeCount,
                             redName = redNameState.text.toString(),
                             blueName = blueNameState.text.toString(),
-//                            isJudging = isJudging,
                         )
                     )
                 },

--- a/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/create/mat/CreateMatMatchContent.kt
+++ b/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/create/mat/CreateMatMatchContent.kt
@@ -87,6 +87,19 @@ fun CreateMatMatchContent(state: CreateMatMatchState, modifier: Modifier) {
             val redNameError = hasAttemptedSubmit && redNameState.text.isBlank()
             val blueNameError = hasAttemptedSubmit && blueNameState.text.isBlank()
 
+            fun submitForm() {
+                hasAttemptedSubmit = true
+                if (matNameState.text.isBlank() || redNameState.text.isBlank() || blueNameState.text.isBlank()) return
+                state.eventSink(
+                    CreateMatMatchEvent.CreateMat(
+                        matName = matNameState.text.toString(),
+                        judgeCount = judgeCount,
+                        redName = redNameState.text.toString(),
+                        blueName = blueNameState.text.toString(),
+                    )
+                )
+            }
+
             Column(
                 modifier = Modifier
                     .widthIn(max = 480.dp)
@@ -146,6 +159,7 @@ fun CreateMatMatchContent(state: CreateMatMatchState, modifier: Modifier) {
                     imeAction = ImeAction.Done,
                     modifier = Modifier.fillMaxWidth(),
                     isError = blueNameError,
+                    onKeyboardAction = { submitForm() },
                 )
 
                 Spacer(Modifier.height(if (isTablet) 80.dp else 64.dp))
@@ -163,18 +177,7 @@ fun CreateMatMatchContent(state: CreateMatMatchState, modifier: Modifier) {
                             Text("Create", style = AccordTypography.labelLarge)
                         }
                     },
-                    onClick = {
-                        hasAttemptedSubmit = true
-                        if (matNameState.text.isBlank() || redNameState.text.isBlank() || blueNameState.text.isBlank()) return@Button
-                        state.eventSink(
-                            CreateMatMatchEvent.CreateMat(
-                                matName = matNameState.text.toString(),
-                                judgeCount = judgeCount,
-                                redName = redNameState.text.toString(),
-                                blueName = blueNameState.text.toString(),
-                            )
-                        )
-                    },
+                    onClick = { submitForm() },
                 )
             }
         }
@@ -215,7 +218,7 @@ private fun JudgeCountEditText(judgeCount: Int, onJudgeCountChange: (count: Int)
             },
             keyboardOptions = KeyboardOptions(
                 keyboardType = KeyboardType.Number,
-                imeAction = ImeAction.Done
+                imeAction = ImeAction.Next
             ),
         )
 

--- a/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/create/mat/CreateMatMatchContent.kt
+++ b/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/create/mat/CreateMatMatchContent.kt
@@ -2,6 +2,7 @@ package dev.jvmname.accord.ui.create.mat
 
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -9,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.text.input.InputTransformation
 import androidx.compose.foundation.text.input.TextFieldLineLimits
@@ -65,13 +67,16 @@ fun CreateMatMatchContent(state: CreateMatMatchState, modifier: Modifier) {
             }
         }
 
-        Column(
+        BoxWithConstraints(
             modifier = modifier
                 .fillMaxSize()
-                .padding(padding)
-                .padding(vertical = 32.dp, horizontal = 16.dp),
-            horizontalAlignment = Alignment.CenterHorizontally
+                .padding(padding),
+            contentAlignment = Alignment.TopCenter,
         ) {
+            val isTablet = maxWidth >= 600.dp
+            val verticalPadding = if (isTablet) 64.dp else 32.dp
+            val sectionSpacing = if (isTablet) 24.dp else 16.dp
+
             val matNameState = rememberTextFieldState()
             val redNameState = rememberTextFieldState()
             val blueNameState = rememberTextFieldState()
@@ -82,91 +87,96 @@ fun CreateMatMatchContent(state: CreateMatMatchState, modifier: Modifier) {
             val redNameError = hasAttemptedSubmit && redNameState.text.isBlank()
             val blueNameError = hasAttemptedSubmit && blueNameState.text.isBlank()
 
-            Text("Mat Info", style = AccordTypography.titleLarge)
+            Column(
+                modifier = Modifier
+                    .widthIn(max = 480.dp)
+                    .fillMaxWidth()
+                    .padding(vertical = verticalPadding, horizontal = 16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                Text("Mat Info", style = AccordTypography.titleLarge)
 
-            Spacer(Modifier.height(16.dp))
+                Spacer(Modifier.height(sectionSpacing))
 
-            Spacer(Modifier.height(16.dp))
-
-            OutlinedTextField(
-                matNameState,
-                modifier = Modifier.fillMaxWidth(),
-                placeholder = { Text("Mat #1") },
-                label = { Text("Mat Name *") },
-                isError = matNameError,
-                supportingText = if (matNameError) {
-                    { Text("Required") }
-                } else null,
-                lineLimits = TextFieldLineLimits.SingleLine,
-                keyboardOptions = KeyboardOptions.Default.copy(
-                    capitalization = KeyboardCapitalization.Words,
-                    imeAction = ImeAction.Next,
-                ),
-            )
-
-            Spacer(Modifier.height(16.dp))
-
-
-            JudgeCountEditText(judgeCount) { judgeCount = it }
-
-            Spacer(Modifier.height(16.dp))
-
-            Text(
-                "Match Info", style = AccordTypography.titleLarge,
-                modifier = Modifier.combinedClickable(
-                    onLongClick = { state.eventSink(CreateMatMatchEvent.LongClick) },
-                    onClick = {}
+                OutlinedTextField(
+                    matNameState,
+                    modifier = Modifier.fillMaxWidth(),
+                    placeholder = { Text("Mat #1") },
+                    label = { Text("Mat Name *") },
+                    isError = matNameError,
+                    supportingText = if (matNameError) {
+                        { Text("Required") }
+                    } else null,
+                    lineLimits = TextFieldLineLimits.SingleLine,
+                    keyboardOptions = KeyboardOptions.Default.copy(
+                        capitalization = KeyboardCapitalization.Words,
+                        imeAction = ImeAction.Next,
+                    ),
                 )
-            )
 
-            Spacer(Modifier.height(16.dp))
+                Spacer(Modifier.height(sectionSpacing))
 
-            CompetitorEditText(
-                competitor = Competitor.RED,
-                state = redNameState,
-                imeAction = ImeAction.Next,
-                modifier = Modifier.fillMaxWidth(),
-                isError = redNameError,
-            )
+                JudgeCountEditText(judgeCount) { judgeCount = it }
 
-            Spacer(Modifier.height(16.dp))
+                Spacer(Modifier.height(sectionSpacing))
 
-            CompetitorEditText(
-                competitor = Competitor.BLUE,
-                state = blueNameState,
-                imeAction = ImeAction.Done,
-                modifier = Modifier.fillMaxWidth(),
-                isError = blueNameError,
-            )
-
-            Spacer(Modifier.height(64.dp))
-
-            Button(
-                modifier = Modifier.fillMaxWidth(),
-                content = {
-                    if (state.loading) {
-                        CircularProgressIndicator(
-                            modifier = Modifier.height(ButtonDefaults.MinHeight),
-                            color = MaterialTheme.colorScheme.onPrimary,
-                            trackColor = MaterialTheme.colorScheme.onPrimaryContainer
-                        )
-                    } else {
-                        Text("Create", style = AccordTypography.labelLarge)
-                    }
-                },
-                onClick = {
-                    hasAttemptedSubmit = true
-                    if (matNameState.text.isBlank() || redNameState.text.isBlank() || blueNameState.text.isBlank()) return@Button
-                    state.eventSink(
-                        CreateMatMatchEvent.CreateMat(
-                            matName = matNameState.text.toString(),
-                            judgeCount = judgeCount,
-                            redName = redNameState.text.toString(),
-                            blueName = blueNameState.text.toString(),
-                        )
+                Text(
+                    "Match Info", style = AccordTypography.titleLarge,
+                    modifier = Modifier.combinedClickable(
+                        onLongClick = { state.eventSink(CreateMatMatchEvent.LongClick) },
+                        onClick = {}
                     )
-                },
-            )
+                )
+
+                Spacer(Modifier.height(sectionSpacing))
+
+                CompetitorEditText(
+                    competitor = Competitor.RED,
+                    state = redNameState,
+                    imeAction = ImeAction.Next,
+                    modifier = Modifier.fillMaxWidth(),
+                    isError = redNameError,
+                )
+
+                Spacer(Modifier.height(sectionSpacing))
+
+                CompetitorEditText(
+                    competitor = Competitor.BLUE,
+                    state = blueNameState,
+                    imeAction = ImeAction.Done,
+                    modifier = Modifier.fillMaxWidth(),
+                    isError = blueNameError,
+                )
+
+                Spacer(Modifier.height(if (isTablet) 80.dp else 64.dp))
+
+                Button(
+                    modifier = Modifier.fillMaxWidth(),
+                    content = {
+                        if (state.loading) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.height(ButtonDefaults.MinHeight),
+                                color = MaterialTheme.colorScheme.onPrimary,
+                                trackColor = MaterialTheme.colorScheme.onPrimaryContainer
+                            )
+                        } else {
+                            Text("Create", style = AccordTypography.labelLarge)
+                        }
+                    },
+                    onClick = {
+                        hasAttemptedSubmit = true
+                        if (matNameState.text.isBlank() || redNameState.text.isBlank() || blueNameState.text.isBlank()) return@Button
+                        state.eventSink(
+                            CreateMatMatchEvent.CreateMat(
+                                matName = matNameState.text.toString(),
+                                judgeCount = judgeCount,
+                                redName = redNameState.text.toString(),
+                                blueName = blueNameState.text.toString(),
+                            )
+                        )
+                    },
+                )
+            }
         }
     }
 
@@ -220,6 +230,8 @@ private fun JudgeCountEditText(judgeCount: Int, onJudgeCountChange: (count: Int)
 }
 
 @Preview
+@Preview(device = "spec:width=1429dp,height=857dp,dpi=224,isRound=false,orientation=landscape")
+
 @Composable
 private fun CreateMatMatchContentPreview() {
     AccordTheme {
@@ -228,6 +240,7 @@ private fun CreateMatMatchContentPreview() {
 }
 
 @Preview
+@Preview(device = "spec:width=1429dp,height=857dp,dpi=224,isRound=false,orientation=landscape")
 @Composable
 private fun CreateMatMatchContentLoadingPreview() {
     AccordTheme {

--- a/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/create/mat/CreateMatMatchPresenter.kt
+++ b/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/create/mat/CreateMatMatchPresenter.kt
@@ -44,7 +44,6 @@ class CreateMatMatchPresenter(
 
                         val event = when (event) {
                             is CreateMatMatchEvent.LongClick -> CreateMatMatchEvent.CreateMat(
-                                masterName = "Test 0",
                                 matName = "Mat 1",
                                 judgeCount = 1,
                                 redName = "RRR",
@@ -58,7 +57,7 @@ class CreateMatMatchPresenter(
                         log.i { "creating mat name='${event.matName}' judges=${event.judgeCount}" }
 
                         matManager.createMatAndMatch(
-                            masterName = event.masterName,
+                            masterName = event.matName,
                             matName = event.matName,
                             judgeCount = event.judgeCount,
                             redName = event.redName,

--- a/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/create/mat/CreateMatMatchScreen.kt
+++ b/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/create/mat/CreateMatMatchScreen.kt
@@ -18,12 +18,10 @@ data class CreateMatMatchState(
 
 sealed interface CreateMatMatchEvent : CircuitUiEvent {
     data class CreateMat(
-        val masterName: String,
         val matName: String,
         val judgeCount: Int,
         val redName: String,
         val blueName: String,
-//        val isJudging: Boolean,
     ) : CreateMatMatchEvent
     data object Back : CreateMatMatchEvent
     data object LongClick : CreateMatMatchEvent

--- a/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/session/judging/JudgeSessionScreen.kt
+++ b/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/session/judging/JudgeSessionScreen.kt
@@ -37,8 +37,11 @@ data class MatchResult(
 ) {
     fun toText(): String {
         return buildString {
-            append("Winner: ", winner.first.name, ' ', winner.second.asEmoji).appendLine()
-            append("Score: ", winnerScore, " to ", loserScore, "(", winConditions, ")").appendLine()
+//            append("Winner: ", winner.first.name, ' ', winner.second.asEmoji).appendLine()
+//            append("Score: ", winnerScore, " to ", loserScore, "(", winConditions, ")").appendLine()
+            roundWinners.forEach {
+                append(it.asEmoji).append(' ')
+            }
         }
     }
 }

--- a/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/session/judging/JudgeSessionScreen.kt
+++ b/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/session/judging/JudgeSessionScreen.kt
@@ -6,7 +6,6 @@ import com.slack.circuit.runtime.CircuitUiState
 import dev.jvmname.accord.domain.Competitor
 import dev.jvmname.accord.domain.asEmoji
 import dev.jvmname.accord.domain.control.HapticEvent
-import dev.jvmname.accord.network.User
 import dev.jvmname.accord.parcel.CommonParcelize
 import dev.jvmname.accord.parcel.ParcelableScreen
 import dev.jvmname.accord.ui.session.JudgeSessionEvent
@@ -30,15 +29,17 @@ data class JudgeSessionState(
 
 @Immutable
 data class MatchResult(
-    val winner: Pair<User, Competitor>,
-    val winnerScore: Int,
-    val loserScore: Int,
-    val winConditions: String
+//    val winner: Pair<User, Competitor>,
+//    val winnerScore: Int,
+//    val loserScore: Int,
+    val winConditions: String,
+    val roundWinners: List<Competitor>,
 ) {
     fun toText(): String {
         return buildString {
 //            append("Winner: ", winner.first.name, ' ', winner.second.asEmoji).appendLine()
 //            append("Score: ", winnerScore, " to ", loserScore, "(", winConditions, ")").appendLine()
+            append("Results: ")
             roundWinners.forEach {
                 append(it.asEmoji).append(' ')
             }

--- a/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/session/master/MasterSessionContent.kt
+++ b/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/session/master/MasterSessionContent.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.slack.circuit.codegen.annotations.CircuitInject
 import com.slack.circuit.overlay.OverlayEffect
 import com.slack.circuitx.overlays.BottomSheetOverlay
@@ -32,6 +33,7 @@ import dev.jvmname.accord.ui.session.MatchActions
 import dev.jvmname.accord.ui.session.MatchState
 import dev.jvmname.accord.ui.session.judging.MatchResult
 import dev.jvmname.accord.ui.theme.AccordTheme
+import dev.jvmname.accord.ui.theme.TabletMainNumber
 
 @[Composable CircuitInject(MasterSessionScreen::class, MatchScope::class)]
 fun MasterSessionContent(state: MasterSessionState, modifier: Modifier = Modifier) {
@@ -109,11 +111,14 @@ fun MasterSessionContent(state: MasterSessionState, modifier: Modifier = Modifie
             Text(
                 state.matchState.timerDisplay,
                 style = MaterialTheme.typography.displayLargeEmphasized,
+                fontSize = 84.sp,
                 fontWeight = FontWeight.Medium,
                 color = MaterialTheme.colorScheme.onSurface
             )
 
-            state.matchState.roundLabel?.let { Text(it) }
+            state.matchState.roundLabel?.let {
+                Text(it, style = MaterialTheme.typography.displayLarge)
+            }
 
             // Score row
             Row(
@@ -121,18 +126,19 @@ fun MasterSessionContent(state: MasterSessionState, modifier: Modifier = Modifie
                 horizontalArrangement = Arrangement.SpaceEvenly
             ) {
                 Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                    Text(state.redName, style = MaterialTheme.typography.bodyMedium)
+                    Text(state.redName, style = MaterialTheme.typography.displayLarge)
                     Text(
                         "${state.matchState.score.redPoints}",
-                        style = MaterialTheme.typography.displayLarge,
+                        style = MaterialTheme.typography.TabletMainNumber,
                         color = Color.Red
                     )
                 }
                 Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                    Text(state.blueName, style = MaterialTheme.typography.bodyMedium)
+                    Text(state.blueName, style = MaterialTheme.typography.displayLarge)
                     Text(
                         "${state.matchState.score.bluePoints}",
-                        style = MaterialTheme.typography.displayLarge,
+                        style = MaterialTheme.typography.TabletMainNumber,
+                        fontSize = 84.sp,
                         color = Color.Blue,
                     )
                 }
@@ -140,7 +146,8 @@ fun MasterSessionContent(state: MasterSessionState, modifier: Modifier = Modifie
 
             // Control buttons
             val roundInfo = state.matchState.roundInfo
-            val isActiveBreak = roundInfo?.round is RoundInfo.Break && roundInfo.state == RoundEvent.RoundState.STARTED
+            val isActiveBreak =
+                roundInfo?.round is RoundInfo.Break && roundInfo.state == RoundEvent.RoundState.STARTED
             if (!isActiveBreak && roundInfo?.state == RoundEvent.RoundState.ENDED) {
                 IconTextButton(
                     modifier = Modifier.fillMaxWidth(),
@@ -228,7 +235,7 @@ fun MasterSessionContent(state: MasterSessionState, modifier: Modifier = Modifie
 
 
 // Match started, active round in progress — pause + end round + end match visible
-@Preview
+@Preview(device = "id:medium_tablet")
 @Composable
 private fun MasterSessionContent_ActiveRound_Preview() {
     AccordTheme {
@@ -246,7 +253,7 @@ private fun MasterSessionContent_ActiveRound_Preview() {
                         techFallWin = null,
                     ),
                     roundInfo = null,
-                    timerDisplay = "02:07",
+                    timerDisplay = "2:07",
                     roundLabel = "Round 2",
                     controlDurations = emptyMap(),
                     roundScores = emptyMap(),
@@ -267,7 +274,7 @@ private fun MasterSessionContent_ActiveRound_Preview() {
 }
 
 // Match started, between rounds — only end match visible
-@Preview
+@Preview(device = "id:medium_tablet")
 @Composable
 private fun MasterSessionContent_BetweenRounds_Preview() {
     AccordTheme {
@@ -303,7 +310,7 @@ private fun MasterSessionContent_BetweenRounds_Preview() {
     }
 }
 
-@Preview
+@Preview(device = "id:medium_tablet")
 @Composable
 private fun MasterSessionContent_Start_Preview() {
     AccordTheme {
@@ -333,7 +340,7 @@ private fun MasterSessionContent_Start_Preview() {
     }
 }
 
-@Preview
+@Preview(device = "id:medium_tablet")
 @Composable
 private fun MasterSessionContent_Ended_Preview() {
     AccordTheme {
@@ -372,7 +379,7 @@ private fun MasterSessionContent_Ended_Preview() {
     }
 }
 
-@Preview
+@Preview(device = "id:medium_tablet")
 @Composable
 private fun MasterSessionContent_Dialog_Preview() {
     AccordTheme {
@@ -402,7 +409,7 @@ private fun MasterSessionContent_Dialog_Preview() {
     }
 }
 
-@Preview
+@Preview(device = "id:medium_tablet")
 @Composable
 private fun MasterSessionContent_Paused_Preview() {
     AccordTheme {
@@ -432,7 +439,7 @@ private fun MasterSessionContent_Paused_Preview() {
     }
 }
 
-@Preview
+@Preview(device = "id:medium_tablet")
 @Composable
 private fun MasterSessionContent_Error_Preview() {
     AccordTheme {

--- a/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/session/master/MasterSessionContent.kt
+++ b/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/session/master/MasterSessionContent.kt
@@ -214,8 +214,9 @@ fun MasterSessionContent(state: MasterSessionState, modifier: Modifier = Modifie
                     IconTextButton(
                         modifier = buttonModifier,
                         icon = Icons.Default.HeartBroken,
-                        text = "Stop Round",
-                        onClick = endRound
+                        text = "Submission",
+                        onClick = endRound,
+                        colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error),
                     )
                 }
                 state.actions.resume?.let { resume ->
@@ -226,7 +227,7 @@ fun MasterSessionContent(state: MasterSessionState, modifier: Modifier = Modifie
                         onClick = resume
                     )
                 }
-                if (state.isMatchStarted && state.matchResult == null) {
+                if (state.isMatchStarted && state.matchResult == null && isActiveBreak) {
                     IconTextButton(
                         modifier = buttonModifier,
                         icon = Icons.Default.StopCircle,

--- a/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/session/master/MasterSessionContent.kt
+++ b/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/session/master/MasterSessionContent.kt
@@ -125,7 +125,7 @@ fun MasterSessionContent(state: MasterSessionState, modifier: Modifier = Modifie
             modifier = Modifier
                 .padding(padding)
                 .fillMaxSize()
-                .padding(16.dp),
+                .padding(vertical = 72.dp, horizontal = 16.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
@@ -178,9 +178,9 @@ fun MasterSessionContent(state: MasterSessionState, modifier: Modifier = Modifie
             val roundInfo = state.matchState.roundInfo
             val isActiveBreak =
                 roundInfo?.round is RoundInfo.Break && roundInfo.state == RoundEvent.RoundState.STARTED
-            val buttonModifier = Modifier.width(200.dp).height(80.dp)
+            val buttonModifier = Modifier.width(275.dp).height(105.dp)
             FlowRow(
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier.fillMaxWidth().padding(top = 64.dp),
                 horizontalArrangement = Arrangement.spacedBy(12.dp, Alignment.CenterHorizontally),
                 verticalArrangement = Arrangement.spacedBy(12.dp),
             ) {

--- a/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/session/master/MasterSessionContent.kt
+++ b/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/session/master/MasterSessionContent.kt
@@ -16,9 +16,18 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.NextPlan
-import androidx.compose.material.icons.filled.*
+import androidx.compose.material.icons.filled.HeartBroken
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Password
+import androidx.compose.material.icons.filled.Pause
+import androidx.compose.material.icons.filled.StopCircle
 import androidx.compose.material.icons.outlined.PlayArrow
-import androidx.compose.material3.*
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -34,8 +43,6 @@ import dev.jvmname.accord.domain.Competitor
 import dev.jvmname.accord.domain.control.rounds.RoundEvent
 import dev.jvmname.accord.domain.control.rounds.RoundInfo
 import dev.jvmname.accord.domain.control.score.Score
-import dev.jvmname.accord.network.User
-import dev.jvmname.accord.network.UserId
 import dev.jvmname.accord.ui.common.IconTextButton
 import dev.jvmname.accord.ui.common.StandardScaffold
 import dev.jvmname.accord.ui.session.MasterSessionEvent
@@ -387,10 +394,8 @@ private fun MasterSessionContent_Ended_Preview() {
                 ),
                 isMatchStarted = true,
                 matchResult = MatchResult(
-                    winner = User(UserId("1"), "Alice") to Competitor.RED,
-                    winnerScore = 2,
-                    loserScore = 1,
                     winConditions = "Points (12s), Points (9s)",
+                    roundWinners = listOf(Competitor.RED, Competitor.BLUE, Competitor.RED)
                 ),
                 actions = MatchActions(),
                 showEndRoundDialog = false,

--- a/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/session/master/MasterSessionContent.kt
+++ b/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/session/master/MasterSessionContent.kt
@@ -1,7 +1,18 @@
 package dev.jvmname.accord.ui.session.master
 
 import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.NextPlan
@@ -15,7 +26,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.slack.circuit.codegen.annotations.CircuitInject
 import com.slack.circuit.overlay.OverlayEffect
 import com.slack.circuitx.overlays.BottomSheetOverlay
@@ -33,8 +43,11 @@ import dev.jvmname.accord.ui.session.MatchActions
 import dev.jvmname.accord.ui.session.MatchState
 import dev.jvmname.accord.ui.session.judging.MatchResult
 import dev.jvmname.accord.ui.theme.AccordTheme
-import dev.jvmname.accord.ui.theme.TabletMainNumber
+import dev.jvmname.accord.ui.theme.TabletCompetitor
+import dev.jvmname.accord.ui.theme.TabletScore
+import dev.jvmname.accord.ui.theme.TabletTimeDisplay
 
+@OptIn(ExperimentalLayoutApi::class)
 @[Composable CircuitInject(MasterSessionScreen::class, MatchScope::class)]
 fun MasterSessionContent(state: MasterSessionState, modifier: Modifier = Modifier) {
     if (state.showEndRoundDialog) {
@@ -108,38 +121,46 @@ fun MasterSessionContent(state: MasterSessionState, modifier: Modifier = Modifie
             verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
 
-            Text(
-                state.matchState.timerDisplay,
-                style = MaterialTheme.typography.displayLargeEmphasized,
-                fontSize = 84.sp,
-                fontWeight = FontWeight.Medium,
-                color = MaterialTheme.colorScheme.onSurface
-            )
-
-            state.matchState.roundLabel?.let {
-                Text(it, style = MaterialTheme.typography.displayLarge)
-            }
-
-            // Score row
+            // Combined scores + timer/label row
             Row(
                 modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceEvenly
+                verticalAlignment = Alignment.CenterVertically,
             ) {
-                Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                    Text(state.redName, style = MaterialTheme.typography.displayLarge)
+                Column(
+                    modifier = Modifier.weight(0.31f),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    Text(state.redName, style = MaterialTheme.typography.TabletCompetitor)
                     Text(
-                        "${state.matchState.score.redPoints}",
-                        style = MaterialTheme.typography.TabletMainNumber,
-                        color = Color.Red
+                        "${10 + state.matchState.score.redPoints}",
+                        style = MaterialTheme.typography.TabletScore,
+                        color = Color.Red,
+                        softWrap = false,
                     )
                 }
-                Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                    Text(state.blueName, style = MaterialTheme.typography.displayLarge)
+                Column(
+                    modifier = Modifier.weight(0.38f),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
                     Text(
-                        "${state.matchState.score.bluePoints}",
-                        style = MaterialTheme.typography.TabletMainNumber,
-                        fontSize = 84.sp,
+                        state.matchState.timerDisplay,
+                        style = MaterialTheme.typography.TabletTimeDisplay,
+                        color = MaterialTheme.colorScheme.onSurface,
+                    )
+                    state.matchState.roundLabel?.let {
+                        Text(it, style = MaterialTheme.typography.displayLarge)
+                    }
+                }
+                Column(
+                    modifier = Modifier.weight(0.31f),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    Text(state.blueName, style = MaterialTheme.typography.TabletCompetitor)
+                    Text(
+                        "${10 + state.matchState.score.bluePoints}",
+                        style = MaterialTheme.typography.TabletScore,
                         color = Color.Blue,
+                        softWrap = false,
                     )
                 }
             }
@@ -148,73 +169,80 @@ fun MasterSessionContent(state: MasterSessionState, modifier: Modifier = Modifie
             val roundInfo = state.matchState.roundInfo
             val isActiveBreak =
                 roundInfo?.round is RoundInfo.Break && roundInfo.state == RoundEvent.RoundState.STARTED
-            if (!isActiveBreak && roundInfo?.state == RoundEvent.RoundState.ENDED) {
-                IconTextButton(
-                    modifier = Modifier.fillMaxWidth(),
-                    icon = Icons.AutoMirrored.Outlined.NextPlan,
-                    text = "Start Next Round",
-                    onClick = { state.eventSink(MasterSessionEvent.StartRound) }
-                )
-            }
+            val buttonModifier = Modifier.width(200.dp).height(80.dp)
+            FlowRow(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(12.dp, Alignment.CenterHorizontally),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                if (!isActiveBreak && roundInfo?.state == RoundEvent.RoundState.ENDED) {
+                    IconTextButton(
+                        modifier = buttonModifier,
+                        icon = Icons.AutoMirrored.Outlined.NextPlan,
+                        text = "Start Next Round",
+                        onClick = { state.eventSink(MasterSessionEvent.StartRound) }
+                    )
+                }
 
-            if (!state.isMatchStarted && state.matchResult == null) {
-                IconTextButton(
-                    modifier = Modifier.fillMaxWidth(),
-                    icon = Icons.Outlined.PlayArrow,
-                    text = "Start Match",
-                    onClick = { state.eventSink(MasterSessionEvent.StartMatch) }
-                )
-            }
+                if (!state.isMatchStarted && state.matchResult == null) {
+                    IconTextButton(
+                        modifier = buttonModifier,
+                        icon = Icons.Outlined.PlayArrow,
+                        text = "Start Match",
+                        onClick = { state.eventSink(MasterSessionEvent.StartMatch) }
+                    )
+                }
 
-            state.actions.pause?.let { pause ->
-                IconTextButton(
-                    modifier = Modifier.fillMaxWidth(),
-                    icon = Icons.Default.Pause,
-                    text = "Pause",
-                    onClick = pause,
-                )
-            }
-            state.actions.endRound?.let { endRound ->
-                IconTextButton(
-                    modifier = Modifier.fillMaxWidth(),
-                    icon = Icons.Default.HeartBroken,
-                    text = "Stop Round",
-                    onClick = endRound
-                )
-            }
-            state.actions.resume?.let { resume ->
-                IconTextButton(
-                    modifier = Modifier.fillMaxWidth(),
-                    icon = Icons.Outlined.PlayArrow,
-                    text = "Resume",
-                    onClick = resume
-                )
-            }
-            if (state.isMatchStarted && state.matchResult == null) {
-                IconTextButton(
-                    modifier = Modifier.fillMaxWidth(),
-                    icon = Icons.Default.StopCircle,
-                    text = "End Match",
-                    colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error),
-                    onClick = { state.eventSink(MasterSessionEvent.EndMatch) }
-                )
+                state.actions.pause?.let { pause ->
+                    IconTextButton(
+                        modifier = buttonModifier,
+                        icon = Icons.Default.Pause,
+                        text = "Pause",
+                        onClick = pause,
+                    )
+                }
+                state.actions.endRound?.let { endRound ->
+                    IconTextButton(
+                        modifier = buttonModifier,
+                        icon = Icons.Default.HeartBroken,
+                        text = "Stop Round",
+                        onClick = endRound
+                    )
+                }
+                state.actions.resume?.let { resume ->
+                    IconTextButton(
+                        modifier = buttonModifier,
+                        icon = Icons.Outlined.PlayArrow,
+                        text = "Resume",
+                        onClick = resume
+                    )
+                }
+                if (state.isMatchStarted && state.matchResult == null) {
+                    IconTextButton(
+                        modifier = buttonModifier,
+                        icon = Icons.Default.StopCircle,
+                        text = "End Match",
+                        colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error),
+                        onClick = { state.eventSink(MasterSessionEvent.EndMatch) }
+                    )
+                }
             }
 
             state.matchResult?.let { matchResult ->
                 Text(
                     "Match Complete",
-                    style = MaterialTheme.typography.headlineMedium,
+                    style = MaterialTheme.typography.displayLargeEmphasized,
                     modifier = Modifier.padding(bottom = 16.dp)
                 )
 
                 Text(
                     matchResult.toText(),
-                    style = MaterialTheme.typography.bodyLarge,
+                    style = MaterialTheme.typography.displayLarge,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
 
                 IconTextButton(
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = buttonModifier,
                     icon = Icons.Default.Home,
                     text = "Return to Main",
                     onClick = { state.eventSink(MasterSessionEvent.ReturnToMain) }
@@ -246,7 +274,7 @@ private fun MasterSessionContent_ActiveRound_Preview() {
                 blueName = "Bob",
                 matchState = MatchState(
                     score = Score(
-                        redPoints = 3,
+                        redPoints = 13,
                         bluePoints = 1,
                         activeControlTime = null,
                         activeCompetitor = null,
@@ -286,7 +314,7 @@ private fun MasterSessionContent_BetweenRounds_Preview() {
                 matchState = MatchState(
                     score = Score(
                         redPoints = 3,
-                        bluePoints = 1,
+                        bluePoints = 14,
                         activeControlTime = null,
                         activeCompetitor = null,
                         techFallWin = null,

--- a/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/session/master/MasterSessionContent.kt
+++ b/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/session/master/MasterSessionContent.kt
@@ -43,6 +43,7 @@ import dev.jvmname.accord.domain.Competitor
 import dev.jvmname.accord.domain.control.rounds.RoundEvent
 import dev.jvmname.accord.domain.control.rounds.RoundInfo
 import dev.jvmname.accord.domain.control.score.Score
+import dev.jvmname.accord.ui.LockLandscape
 import dev.jvmname.accord.ui.common.IconTextButton
 import dev.jvmname.accord.ui.common.StandardScaffold
 import dev.jvmname.accord.ui.session.MasterSessionEvent
@@ -57,6 +58,7 @@ import dev.jvmname.accord.ui.theme.TabletTimeDisplay
 @OptIn(ExperimentalLayoutApi::class)
 @[Composable CircuitInject(MasterSessionScreen::class, MatchScope::class)]
 fun MasterSessionContent(state: MasterSessionState, modifier: Modifier = Modifier) {
+    LockLandscape()
     if (state.showEndRoundDialog) {
         OverlayEffect(state.showEndRoundDialog) {
             val result = show(
@@ -139,7 +141,7 @@ fun MasterSessionContent(state: MasterSessionState, modifier: Modifier = Modifie
                 ) {
                     Text(state.redName, style = MaterialTheme.typography.TabletCompetitor)
                     Text(
-                        "${10 + state.matchState.score.redPoints}",
+                        state.matchState.score.redPoints.toString(),
                         style = MaterialTheme.typography.TabletScore,
                         color = Color.Red,
                         softWrap = false,
@@ -164,7 +166,7 @@ fun MasterSessionContent(state: MasterSessionState, modifier: Modifier = Modifie
                 ) {
                     Text(state.blueName, style = MaterialTheme.typography.TabletCompetitor)
                     Text(
-                        "${10 + state.matchState.score.bluePoints}",
+                        "${state.matchState.score.bluePoints}",
                         style = MaterialTheme.typography.TabletScore,
                         color = Color.Blue,
                         softWrap = false,
@@ -270,7 +272,7 @@ fun MasterSessionContent(state: MasterSessionState, modifier: Modifier = Modifie
 
 
 // Match started, active round in progress — pause + end round + end match visible
-@Preview(device = "id:medium_tablet")
+@Preview(device = "spec:width=1429dp,height=857dp,dpi=224,isRound=false,orientation=landscape")
 @Composable
 private fun MasterSessionContent_ActiveRound_Preview() {
     AccordTheme {
@@ -309,7 +311,7 @@ private fun MasterSessionContent_ActiveRound_Preview() {
 }
 
 // Match started, between rounds — only end match visible
-@Preview(device = "id:medium_tablet")
+@Preview(device = "spec:width=1429dp,height=857dp,dpi=224,isRound=false,orientation=landscape")
 @Composable
 private fun MasterSessionContent_BetweenRounds_Preview() {
     AccordTheme {
@@ -345,7 +347,7 @@ private fun MasterSessionContent_BetweenRounds_Preview() {
     }
 }
 
-@Preview(device = "id:medium_tablet")
+@Preview(device = "spec:width=1429dp,height=857dp,dpi=224,isRound=false,orientation=landscape")
 @Composable
 private fun MasterSessionContent_Start_Preview() {
     AccordTheme {
@@ -375,7 +377,7 @@ private fun MasterSessionContent_Start_Preview() {
     }
 }
 
-@Preview(device = "id:medium_tablet")
+@Preview(device = "spec:width=1429dp,height=857dp,dpi=224,isRound=false,orientation=landscape")
 @Composable
 private fun MasterSessionContent_Ended_Preview() {
     AccordTheme {
@@ -412,7 +414,7 @@ private fun MasterSessionContent_Ended_Preview() {
     }
 }
 
-@Preview(device = "id:medium_tablet")
+@Preview(device = "spec:width=1429dp,height=857dp,dpi=224,isRound=false,orientation=landscape")
 @Composable
 private fun MasterSessionContent_Dialog_Preview() {
     AccordTheme {
@@ -442,7 +444,7 @@ private fun MasterSessionContent_Dialog_Preview() {
     }
 }
 
-@Preview(device = "id:medium_tablet")
+@Preview(device = "spec:width=1429dp,height=857dp,dpi=224,isRound=false,orientation=landscape")
 @Composable
 private fun MasterSessionContent_Paused_Preview() {
     AccordTheme {
@@ -472,7 +474,7 @@ private fun MasterSessionContent_Paused_Preview() {
     }
 }
 
-@Preview(device = "id:medium_tablet")
+@Preview(device = "spec:width=1429dp,height=857dp,dpi=224,isRound=false,orientation=landscape")
 @Composable
 private fun MasterSessionContent_Error_Preview() {
     AccordTheme {

--- a/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/session/master/overlay.kt
+++ b/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/session/master/overlay.kt
@@ -9,6 +9,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -80,6 +81,10 @@ internal fun SubmissionDialog(overlayNavigator: OverlayNavigator<SubmissionResul
                     border = SegmentedButtonDefaults.borderStroke(competitor.color),
                     onClick = { selected = competitor },
                     selected = competitor == selected,
+                    colors = SegmentedButtonDefaults.colors(
+                        activeContainerColor = competitor.color,
+                        activeContentColor = Color.White,
+                    ),
                     label = { Text(competitor.nameStr) }
                 )
             }

--- a/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/theme/Type.kt
+++ b/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/theme/Type.kt
@@ -1,6 +1,8 @@
 package dev.jvmname.accord.ui.theme
 
 import androidx.compose.material3.Typography
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.sp
 
 private val baseline = Typography()
 
@@ -21,3 +23,6 @@ val AccordTypography = Typography(
     labelMedium = baseline.labelMedium,
     labelSmall = baseline.labelSmall
 )
+
+val Typography.TabletMainNumber: TextStyle
+    get() = AccordTypography.displayLarge.copy(fontSize = 84.sp)

--- a/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/theme/Type.kt
+++ b/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/theme/Type.kt
@@ -2,6 +2,9 @@ package dev.jvmname.accord.ui.theme
 
 import androidx.compose.material3.Typography
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.LineHeightStyle
+import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
 
 private val baseline = Typography()
@@ -24,5 +27,25 @@ val AccordTypography = Typography(
     labelSmall = baseline.labelSmall
 )
 
-val Typography.TabletMainNumber: TextStyle
-    get() = AccordTypography.displayLarge.copy(fontSize = 84.sp)
+val Typography.TabletScore: TextStyle
+    get() = AccordTypography.displayLarge.copy(
+        fontSize = 330.sp,
+        lineHeight = 0.75.em,
+        lineHeightStyle = LineHeightStyle.Default.copy(
+            mode = LineHeightStyle.Mode.Tight
+        ),
+        fontWeight = FontWeight.Bold
+    )
+
+val Typography.TabletCompetitor: TextStyle
+    get() = AccordTypography.displayLarge.copy(
+        fontSize = 75.sp,
+        fontWeight = FontWeight.Bold
+    )
+
+
+val Typography.TabletTimeDisplay: TextStyle
+    get() = AccordTypography.displayLarge.copy(
+        fontSize = 170.sp,
+        fontWeight = FontWeight.Medium,
+    )

--- a/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/util.kt
+++ b/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/util.kt
@@ -2,6 +2,7 @@ package dev.jvmname.accord.ui
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.RememberObserver
+
 import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.annotation.UnsafeResultErrorAccess
 import com.github.michaelbull.result.annotation.UnsafeResultValueAccess
@@ -16,6 +17,10 @@ import top.ltfan.multihaptic.vibrator.Vibrator
 import java.util.Locale
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
+
+
+@Composable
+expect fun LockLandscape()
 
 // https://chrisbanes.me/posts/retaining-beyond-viewmodels/
 @Composable

--- a/app/app/src/jvmMain/kotlin/dev/jvmname/accord/main.kt
+++ b/app/app/src/jvmMain/kotlin/dev/jvmname/accord/main.kt
@@ -20,8 +20,8 @@ import kotlin.time.Clock
 fun main() = application {
     val windowState =
         rememberWindowState(
-            width = 1200.dp,
-            height = 800.dp,
+            width = 1429.dp,
+            height = 857.dp,
             position = WindowPosition(Alignment.Center),
         )
 

--- a/app/app/src/jvmMain/kotlin/dev/jvmname/accord/ui/util.jvm.kt
+++ b/app/app/src/jvmMain/kotlin/dev/jvmname/accord/ui/util.jvm.kt
@@ -1,0 +1,6 @@
+package dev.jvmname.accord.ui
+
+import androidx.compose.runtime.Composable
+
+@Composable
+actual fun LockLandscape() = Unit


### PR DESCRIPTION
## Summary
- Landscape layout for master session screen (Galaxy Tab S6 Lite optimized)
- Typography scaling — bigger fonts throughout master and judge screens
- Emoji round result display replacing verbose text
- Color/spacing adjustments on master screen and overlays
- Remove master tablet label; use mat name instead
- Keyboard navigation on create match screen

## Test plan
- [ ] Verify landscape layout on master session (tablet)
- [ ] Verify match result emoji display after all 3 rounds
- [ ] Verify keyboard nav (tab/enter) works on create match screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)