### PR TITLE
Simplify submissions: replace submission field with winner/stoppage

### DIFF
--- a/app/app/src/commonMain/kotlin/dev/jvmname/accord/domain/Competitor.kt
+++ b/app/app/src/commonMain/kotlin/dev/jvmname/accord/domain/Competitor.kt
@@ -3,7 +3,7 @@ package dev.jvmname.accord.domain
 import androidx.compose.ui.graphics.Color
 import dev.jvmname.accord.network.CompetitorColor
 import dev.jvmname.accord.ui.capitalize
-import java.util.*
+import java.util.Locale
 
 enum class Competitor {
     RED, BLUE

--- a/app/app/src/commonMain/kotlin/dev/jvmname/accord/domain/MatchManager.kt
+++ b/app/app/src/commonMain/kotlin/dev/jvmname/accord/domain/MatchManager.kt
@@ -8,7 +8,15 @@ import com.github.michaelbull.result.onOk
 import com.github.michaelbull.retry.policy.stopAtAttempts
 import com.github.michaelbull.retry.retry
 import dev.jvmname.accord.di.MatchScope
-import dev.jvmname.accord.network.*
+import dev.jvmname.accord.network.AccordClient
+import dev.jvmname.accord.network.CompetitorColor
+import dev.jvmname.accord.network.CompetitorRequest
+import dev.jvmname.accord.network.Match
+import dev.jvmname.accord.network.MatchId
+import dev.jvmname.accord.network.NetworkResult
+import dev.jvmname.accord.network.SocketClient
+import dev.jvmname.accord.network.flatMapping
+import dev.jvmname.accord.network.merge
 import dev.jvmname.accord.prefs.Prefs
 import dev.jvmname.accord.ui.catchRunning
 import dev.zacsweers.metro.Inject
@@ -131,13 +139,11 @@ class MatchManager(
 
     suspend fun endRound(
         matchId: MatchId,
-        submission: String? = null,
-        submitter: Competitor? = null,
-        stoppage: Boolean = false,
-        stopper: Competitor? = null,
+        winner: Competitor?,
+        stoppage: Boolean?,
     ): NetworkResult<Match> {
-        log.i { "ending round matchId=$matchId submission=$submission stoppage=$stoppage" }
-        return client.endRound(matchId, submission, submitter?.asColor, stoppage, stopper?.asColor)
+        log.i { "ending round matchId=$matchId winner=$winner stoppage=$stoppage" }
+        return client.endRound(matchId, winner = winner?.asColor, stoppage = stoppage ?: false)
             .onOk { match ->
                 updateCache(match)
             }

--- a/app/app/src/commonMain/kotlin/dev/jvmname/accord/domain/session/MasterSession.kt
+++ b/app/app/src/commonMain/kotlin/dev/jvmname/accord/domain/session/MasterSession.kt
@@ -19,7 +19,16 @@ import dev.zacsweers.metro.SingleIn
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.runningFold
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
@@ -102,13 +111,10 @@ class MasterSession(
         scope.launch { matchManager.startRound() }
     }
 
-    override fun endRound(winner: Competitor?, submission: String?, stoppage: Boolean) {
+    override fun endRound(winner: Competitor?, stoppage: Boolean?) {
         scope.launch {
             currentMatchId?.let {
-                when {
-                    stoppage -> matchManager.endRound(it, stoppage = true, stopper = winner)
-                    else -> matchManager.endRound(it, submission.orEmpty(), winner)
-                }
+                matchManager.endRound(it, stoppage = stoppage, winner = winner)
             }
         }
     }

--- a/app/app/src/commonMain/kotlin/dev/jvmname/accord/domain/session/MatchSession.kt
+++ b/app/app/src/commonMain/kotlin/dev/jvmname/accord/domain/session/MatchSession.kt
@@ -30,7 +30,7 @@ interface RoundController : PausableSession {
     suspend fun startMatch(): NetworkResult<Match>
     suspend fun endMatch(): NetworkResult<Match>
     fun startRound()
-    fun endRound(winner: Competitor?, submission: String?, stoppage: Boolean = false)
+    fun endRound(winner: Competitor?, stoppage: Boolean?)
     fun manualEdit(competitor: Competitor, action: ManualEditAction)
 }
 

--- a/app/app/src/commonMain/kotlin/dev/jvmname/accord/network/AccordClient.kt
+++ b/app/app/src/commonMain/kotlin/dev/jvmname/accord/network/AccordClient.kt
@@ -8,9 +8,13 @@ import com.github.michaelbull.result.onOk
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
-import io.ktor.client.*
-import io.ktor.client.call.*
-import io.ktor.client.request.*
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.delete
+import io.ktor.client.request.get
+import io.ktor.client.request.parameter
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
@@ -182,15 +186,12 @@ class AccordClient(private val httpClient: HttpClient) {
 
     suspend fun endMatch(
         matchId: MatchId,
-        submission: String? = null,
-        submitter: CompetitorColor? = null,
     ): NetworkResult<Match> {
-        log.d { "endMatch matchId=$matchId submission=${submission != null} submitter=$submitter" }
+        log.d { "endMatch matchId=$matchId " }
         return withContext(Dispatchers.IO) {
             runSuspendCatching {
-                httpClient.post("match/${matchId.id}/end") {
-                    setBody(EndMatchRequest(submission, submitter))
-                }.body<ApiResult<MatchResponseData>>()
+                httpClient.post("match/${matchId.id}/end")
+                    .body<ApiResult<MatchResponseData>>()
             }
                 .unwrapApiResult()
                 .map { it.match }
@@ -219,16 +220,14 @@ class AccordClient(private val httpClient: HttpClient) {
 
     suspend fun endRound(
         matchId: MatchId,
-        submission: String? = null,
-        submitter: CompetitorColor? = null,
-        stoppage: Boolean = false,
-        stopper: CompetitorColor? = null,
+        winner: CompetitorColor?,
+        stoppage: Boolean,
     ): NetworkResult<Match> {
-        log.d { "endRound matchId=$matchId submission=${submission != null} submitter=$submitter stoppage=$stoppage stopper=$stopper" }
+        log.d { "endRound matchId=$matchId winner=$winner stoppage=$stoppage" }
         return withContext(Dispatchers.IO) {
             runSuspendCatching {
                 httpClient.post("match/${matchId.id}/rounds/end") {
-                    setBody(EndRoundRequest(submission, submitter, stoppage.takeIf { it }, stopper))
+                    setBody(EndRoundRequest(winner = winner, stoppage = stoppage))
                 }.body<ApiResult<MatchResponseData>>()
             }
                 .unwrapApiResult()

--- a/app/app/src/commonMain/kotlin/dev/jvmname/accord/network/ApiResultSerializer.kt
+++ b/app/app/src/commonMain/kotlin/dev/jvmname/accord/network/ApiResultSerializer.kt
@@ -48,19 +48,19 @@ class ApiResultSerializer<T>(private val dataSerializer: KSerializer<T>) :
 
             else -> ApiResult.Error(
                 when (dataElement) {
-                    is JsonObject if (dataElement.jsonObject.containsKey("errors")) -> {
+                    is JsonObject if dataElement.containsKey("errors") -> {
                         val errorsSerializer = MapSerializer(
                             String.serializer(),
                             ListSerializer(String.serializer())
                         )
-                        jsonDecoder.json.decodeFromJsonElement(errorsSerializer, dataElement.jsonObject["errors"]!!)
+                        jsonDecoder.json.decodeFromJsonElement(errorsSerializer, dataElement["errors"]!!)
                     }
 
-                    else if (dataElement.jsonObject.containsKey("error")) -> {
-                        mapOf("error" to listOf(dataElement.jsonObject["error"]!!.jsonPrimitive.content))
+                    is JsonObject if dataElement.containsKey("error") -> {
+                        mapOf("error" to listOf(dataElement["error"]!!.jsonPrimitive.content))
                     }
 
-                    else -> throw SerializationException("Missing 'errors'/'error' field in error response")
+                    else -> mapOf("error" to listOf(status))
                 }
             )
         }

--- a/app/app/src/commonMain/kotlin/dev/jvmname/accord/network/models.kt
+++ b/app/app/src/commonMain/kotlin/dev/jvmname/accord/network/models.kt
@@ -159,12 +159,6 @@ enum class CompetitorColor {
     val humanName = name.lowercase()
 }
 
-@[Poko Serializable]
-class EndMatchRequest(
-    val submission: String? = null,
-    val submitter: CompetitorColor? = null,
-)
-
 // ============================================================================
 // Round Models
 // ============================================================================
@@ -212,10 +206,8 @@ enum class RoundResultType {
 
 @[Poko Serializable]
 class EndRoundRequest(
-    val submission: String? = null,
-    val submitter: CompetitorColor? = null,
+    val winner: CompetitorColor? = null,
     val stoppage: Boolean? = null,
-    val stopper: CompetitorColor? = null,
 )
 
 // ============================================================================

--- a/app/app/src/commonMain/kotlin/dev/jvmname/accord/network/models_ext.kt
+++ b/app/app/src/commonMain/kotlin/dev/jvmname/accord/network/models_ext.kt
@@ -79,7 +79,7 @@ val RoundResultType.toHumanString: String
     }
 
 fun Match.toMatchResult(): MatchResult? {
-    val winner = winner!!
+    val winner = winner?: return null
     val winnerC = winnerCompetitor ?: return null
     val scores = roundScore()
     val loser = if (winnerC == Competitor.RED) Competitor.BLUE else Competitor.RED

--- a/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/session/SessionEvents.kt
+++ b/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/session/SessionEvents.kt
@@ -36,10 +36,8 @@ sealed interface MasterSessionEvent : SessionEvent {
     data object Resume : MasterSessionEvent, PausableEvent
     data object StartRound : MasterSessionEvent, RoundControlEvent
     data class EndRound(
-        val submission: String? = null,
-        val submitter: Competitor? = null,
-        val stoppage: Boolean = false,
-        val stopper: Competitor? = null,
+        val winner: Competitor?,
+        val stoppage: Boolean,
     ) : MasterSessionEvent, RoundControlEvent
     data object ShowEndRoundDialog : MasterSessionEvent
     data object DismissEndRoundDialog : MasterSessionEvent

--- a/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/session/master/MasterSessionContent.kt
+++ b/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/session/master/MasterSessionContent.kt
@@ -46,10 +46,8 @@ fun MasterSessionContent(state: MasterSessionState, modifier: Modifier = Modifie
             when (result) {
                 is SubmissionResult.Confirmed -> state.eventSink(
                     MasterSessionEvent.EndRound(
-                        submission = result.submission,
-                        submitter = result.submitter,
-                        stoppage = result.stoppage,
-                        stopper = result.stopper,
+                        winner = result.winner,
+                        stoppage = result.stoppage
                     )
                 )
 

--- a/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/session/master/MasterSessionPresenter.kt
+++ b/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/session/master/MasterSessionPresenter.kt
@@ -1,6 +1,12 @@
 package dev.jvmname.accord.ui.session.master
 
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import co.touchlab.kermit.Logger
 import com.slack.circuit.codegen.annotations.CircuitInject
 import com.slack.circuit.runtime.Navigator
@@ -10,10 +16,16 @@ import dev.jvmname.accord.di.MatchScope
 import dev.jvmname.accord.domain.Competitor
 import dev.jvmname.accord.domain.MatManager
 import dev.jvmname.accord.domain.MatchManager
+import dev.jvmname.accord.domain.color
 import dev.jvmname.accord.domain.control.rounds.RoundEvent
 import dev.jvmname.accord.domain.control.rounds.RoundInfo
 import dev.jvmname.accord.domain.session.MasterSession
-import dev.jvmname.accord.network.*
+import dev.jvmname.accord.network.Mat
+import dev.jvmname.accord.network.adminCode
+import dev.jvmname.accord.network.message
+import dev.jvmname.accord.network.roundScore
+import dev.jvmname.accord.network.toMatchResult
+import dev.jvmname.accord.network.winner
 import dev.jvmname.accord.prefs.Prefs
 import dev.jvmname.accord.ui.onEither
 import dev.jvmname.accord.ui.session.MasterSessionEvent
@@ -121,9 +133,9 @@ class MasterSessionPresenter(
                     }
 
                     is MasterSessionEvent.EndRound -> {
-                        log.i { "ending round submission=${event.submission} stoppage=${event.stoppage}" }
+                        log.i { "ending round: submitter=${event.winner?.name} (${event.winner?.color}), stoppage=${event.stoppage}" }
                         showEndRoundDialog = false
-                        session.endRound(event.submitter ?: event.stopper, event.submission, event.stoppage)
+                        session.endRound(event.winner, event.stoppage)
                     }
 
                     MasterSessionEvent.StartRound -> {

--- a/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/session/master/overlay.kt
+++ b/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/session/master/overlay.kt
@@ -1,12 +1,24 @@
 package dev.jvmname.accord.ui.session.master
 
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.text.input.TextFieldLineLimits
-import androidx.compose.foundation.text.input.rememberTextFieldState
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SegmentedButton
+import androidx.compose.material3.SegmentedButtonDefaults
+import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
@@ -22,18 +34,17 @@ import dev.jvmname.accord.ui.theme.AccordTheme
 internal sealed class SubmissionResult {
     data object Dismissed : SubmissionResult()
     data class Confirmed(
-        val submission: String?,
-        val submitter: Competitor?,
+        val winner: Competitor?,
         val stoppage: Boolean,
-        val stopper: Competitor?,
     ) : SubmissionResult()
+
+    companion object
 }
 
 private enum class EndRoundMethod { SUBMISSION, STOPPAGE }
 
 @Composable
 internal fun SubmissionDialog(overlayNavigator: OverlayNavigator<SubmissionResult>) {
-    val submissionText = rememberTextFieldState()
     var method by remember { mutableStateOf(EndRoundMethod.SUBMISSION) }
     var selected by remember { mutableStateOf<Competitor?>(null) }
 
@@ -60,17 +71,8 @@ internal fun SubmissionDialog(overlayNavigator: OverlayNavigator<SubmissionResul
                 )
             }
         }
-        if (method == EndRoundMethod.SUBMISSION) {
-            OutlinedTextField(
-                state = submissionText,
-                label = { Text("Submission (optional)") },
-                placeholder = { Text("e.g. rear naked choke") },
-                lineLimits = TextFieldLineLimits.SingleLine,
-                modifier = Modifier.fillMaxWidth(),
-            )
-        }
         Text(
-            text = if (method == EndRoundMethod.SUBMISSION) "Who submitted?" else "Who wins?",
+            text = "Who won this round?",
             style = MaterialTheme.typography.bodyMedium,
         )
         SingleChoiceSegmentedButtonRow(Modifier.fillMaxWidth()) {
@@ -91,20 +93,10 @@ internal fun SubmissionDialog(overlayNavigator: OverlayNavigator<SubmissionResul
             TextButton(onClick = { overlayNavigator.finish(SubmissionResult.Dismissed) }) { Text("Cancel") }
             TextButton(onClick = {
                 overlayNavigator.finish(
-                    when (method) {
-                        EndRoundMethod.SUBMISSION -> SubmissionResult.Confirmed(
-                            submission = submissionText.text.ifBlank { null }?.toString(),
-                            submitter = selected,
-                            stoppage = false,
-                            stopper = null,
-                        )
-                        EndRoundMethod.STOPPAGE -> SubmissionResult.Confirmed(
-                            submission = null,
-                            submitter = null,
-                            stoppage = true,
-                            stopper = selected,
-                        )
-                    }
+                    SubmissionResult.Confirmed(
+                        winner = selected,
+                        stoppage = method == EndRoundMethod.STOPPAGE
+                    )
                 )
             }) { Text("Confirm") }
         }

--- a/server/README.md
+++ b/server/README.md
@@ -107,7 +107,7 @@ in the `x-api-token` header. This API token is returned via the user creation en
 ### End a Round
 `POST /match/:matchId/rounds/end`
 ##### request parameters
-`submission` (string with submission name), `submitter` ("red" or "blue") // optional
+`winner` ("red" or "blue", optional), `stoppage` (boolean, optional)
 ##### response
 ```
 {
@@ -126,8 +126,6 @@ in the `x-api-token` header. This API token is returned via the user creation en
 
 ### End a Match
 `POST /match/:matchId/end`
-##### request parameters
-`submission` (string with submission name), `submitter` ("red" or "blue") // optional
 ##### response
 ```
 {

--- a/server/config/db/migrations/replaceSubmissionWithWinnerOnRounds_1775779200000.js
+++ b/server/config/db/migrations/replaceSubmissionWithWinnerOnRounds_1775779200000.js
@@ -1,0 +1,16 @@
+module.exports = {
+    up: async function() {
+        await this.removeColumn('rounds', 'submission');
+        await this.removeColumn('rounds', 'submission_by');
+        await this.addColumn('rounds', 'declared_winner_id', { type: this.DataTypes.UUID, allowNull: true });
+        await this.addColumn('rounds', 'stoppage',           { type: this.DataTypes.BOOLEAN, allowNull: true });
+    },
+
+
+    down: async function () {
+        await this.addColumn('rounds', 'submission',    { type: this.DataTypes.STRING, allowNull: true });
+        await this.addColumn('rounds', 'submission_by', { type: this.DataTypes.UUID, allowNull: true });
+        await this.removeColumn('rounds', 'declared_winner_id');
+        await this.removeColumn('rounds', 'stoppage');
+    }
+}

--- a/server/config/db/schemas/default.js
+++ b/server/config/db/schemas/default.js
@@ -274,50 +274,6 @@ module.exports = {
             "unique": false
         }
     },
-    "rounds": {
-        "id": {
-            "type": "UUID",
-            "allowNull": false,
-            "primaryKey": true,
-            "unique": true
-        },
-        "match_id": {
-            "type": "UUID",
-            "allowNull": false,
-            "primaryKey": false,
-            "unique": false
-        },
-        "submission_by": {
-            "type": "UUID",
-            "allowNull": true,
-            "primaryKey": false,
-            "unique": false
-        },
-        "submission": {
-            "type": "VARCHAR(255)",
-            "allowNull": true,
-            "primaryKey": false,
-            "unique": false
-        },
-        "ended_at": {
-            "type": "DATETIME",
-            "allowNull": true,
-            "primaryKey": false,
-            "unique": false
-        },
-        "created_at": {
-            "type": "DATETIME",
-            "allowNull": false,
-            "primaryKey": false,
-            "unique": false
-        },
-        "updated_at": {
-            "type": "DATETIME",
-            "allowNull": false,
-            "primaryKey": false,
-            "unique": false
-        }
-    },
     "judges_matches": {
         "match_id": {
             "type": "UUID",
@@ -410,6 +366,50 @@ module.exports = {
         "updated_at": {
             "type": "DATETIME",
             "allowNull": false,
+            "primaryKey": false,
+            "unique": false
+        }
+    },
+    "rounds": {
+        "id": {
+            "type": "UUID",
+            "allowNull": false,
+            "primaryKey": true,
+            "unique": true
+        },
+        "match_id": {
+            "type": "UUID",
+            "allowNull": false,
+            "primaryKey": false,
+            "unique": false
+        },
+        "ended_at": {
+            "type": "DATETIME",
+            "allowNull": true,
+            "primaryKey": false,
+            "unique": false
+        },
+        "created_at": {
+            "type": "DATETIME",
+            "allowNull": false,
+            "primaryKey": false,
+            "unique": false
+        },
+        "updated_at": {
+            "type": "DATETIME",
+            "allowNull": false,
+            "primaryKey": false,
+            "unique": false
+        },
+        "declared_winner_id": {
+            "type": "UUID",
+            "allowNull": true,
+            "primaryKey": false,
+            "unique": false
+        },
+        "stoppage": {
+            "type": "TINYINT(1)",
+            "allowNull": true,
             "primaryKey": false,
             "unique": false
         }

--- a/server/controllers/match/roundsController.js
+++ b/server/controllers/match/roundsController.js
@@ -27,9 +27,8 @@ class RoundsController extends ServerController {
 
         try {
             await this.currentMatch.endRound(this.params);
-            const submission = this.params.submission ? ` submission=${this.params.submission} by=${this.params.submitter}` : '';
-            const stoppage   = this.params.stoppage   ? ` stoppage by=${this.params.stopper}` : '';
-            logger.info(`Round ended: match=${this.currentMatch.id} by user=${this.currentUser.id}${submission}${stoppage}`);
+            const winLog = this.params.winner ? ` winner=${this.params.winner} stoppage=${this.params.stoppage}` : '';
+            logger.info(`Round ended: match=${this.currentMatch.id} by user=${this.currentUser.id}${winLog}`);
 
             const options = {includeRounds: true, includeJudges: true, includeMat: true};
             await this.render({match: this.currentMatch}, options);
@@ -104,15 +103,15 @@ class RoundsController extends ServerController {
                 }
             },
             postEndRound: {
-                description: 'End the current round for the specified match, optionally recording a submission and submitter.',
+                description: 'End the current round for the specified match, optionally recording a winner and whether it was by stoppage.',
                 tags: ['match/rounds'],
                 request: {
                     params: {
                         matchId: { type: 'string', required: true }
                     },
                     body: {
-                        submission: { type: 'string' },
-                        submitter:  { type: 'string', enum: ['red', 'blue'] }
+                        winner:   { type: 'string', enum: ['red', 'blue'] },
+                        stoppage: { type: 'boolean' }
                     }
                 },
                 response: {

--- a/server/controllers/matchesController.js
+++ b/server/controllers/matchesController.js
@@ -1,4 +1,3 @@
-const { endRoundValidations } = require('../lib/controllers/roundsControllerHelpers');
 const { logger }              = require('../lib/logger');
 const { Mat }                 = require('../models/mat');
 const { Match }               = require('../models/match');
@@ -54,9 +53,6 @@ class MatchesController extends ServerController {
     async postEndMatch() {
         await this.authorize('manage', this.currentMatch);
 
-        const validations = endRoundValidations.call(this);
-        await this.validateParameters(validations);
-
         if (!this.currentMatch.started) {
             return await this.renderErrors({matchId: ['this match has not started']});
         }
@@ -64,9 +60,8 @@ class MatchesController extends ServerController {
             return await this.renderErrors({matchId: ['this match has already ended']});
         }
 
-        await this.currentMatch.end(this.params);
-        const submission = this.params.submission ? ` submission=${this.params.submission} by=${this.params.submitter}` : '';
-        logger.info(`Match ended: match=${this.currentMatch.id} by user=${this.currentUser.id}${submission}`);
+        await this.currentMatch.end();
+        logger.info(`Match ended: match=${this.currentMatch.id} by user=${this.currentUser.id}`);
         const renderOptions = {includeMat: true, includeMatchJudges: true, includeRounds: true};
         await this.render({match: this.currentMatch}, renderOptions);
     }
@@ -130,10 +125,6 @@ class MatchesController extends ServerController {
                 request: {
                     params: {
                         matchId: { type: 'string', required: true }
-                    },
-                    body: {
-                        submission: { type: 'string' },
-                        submitter:  { type: 'string', enum: ['red', 'blue'] }
                     }
                 },
                 response: {

--- a/server/lib/controllers/roundsControllerHelpers.js
+++ b/server/lib/controllers/roundsControllerHelpers.js
@@ -1,25 +1,8 @@
 function endRoundValidations() {
-    const params              = this.params;
-    const submissionValidator = () => {
-        const { submission, submitter } = params;
-        if (submission  && !submitter) return 'Must include `submitter` when providing submission';
-        if (!submission && submitter)  return 'Must include `submission` when providing submitter';
-    };
-    const stoppageValidator = () => {
-        const { stoppage, stopper } = params;
-        if (stoppage && !stopper) return 'Must include `stopper` when providing stoppage';
-        if (!stoppage && stopper) return 'Must include `stoppage` when providing stopper';
-    };
-
     return {
-        submitter: {function: submissionValidator, isEnum: {enums: [undefined, 'red', 'blue']}},
-        sumission: {function: submissionValidator},
-        stopper:   {function: stoppageValidator,   isEnum: {enums: [undefined, 'red', 'blue']}},
-        stoppage:  {function: stoppageValidator}
-    }
+        winner: { isEnum: { enums: [undefined, 'red', 'blue'] } }
+    };
 }
 
 
-module.exports = {
-    endRoundValidations
-}
+module.exports = { endRoundValidations };

--- a/server/lib/openapi/schemas/round.js
+++ b/server/lib/openapi/schemas/round.js
@@ -67,7 +67,7 @@ const Round = {
                         },
                         value: {
                             type: ["string", "null"],
-                            description: "The submission name or point score as a string; null if round is ongoing"
+                            description: "The point score as a string for points/tech-fall wins; null otherwise"
                         }
                     },
                     required: ["type", "value"],

--- a/server/lib/rules/rDojoKombat.js
+++ b/server/lib/rules/rDojoKombat.js
@@ -40,13 +40,13 @@ const RDojoKombatRules = {
         if (!round.ended) {
             // do nothing
 
-        } else if (round.submission) {
-            winner       = red.id == round.submission_by ? red : blue;
-            method.type  = 'submission'
-            method.value = round.submission;
+        } else if (round.declared_winner_id && !round.stoppage) {
+            winner       = red.id == round.declared_winner_id ? red : blue;
+            method.type  = 'submission';
+            method.value = null;
 
-        } else if (round.stoppage_by) {
-            winner      = red.id == round.stoppage_by ? red : blue;
+        } else if (round.declared_winner_id && round.stoppage) {
+            winner      = red.id == round.declared_winner_id ? red : blue;
             method.type = 'stoppage';
 
         } else if (redScore != blueScore) {

--- a/server/models/match.js
+++ b/server/models/match.js
@@ -115,14 +115,13 @@ class Match extends BaseRecord {
     }
 
 
-    async endRound({ submission, submitter, safe }={}) {
+    async endRound({ winner, stoppage, safe }={}) {
         const lastRound = await this.getLastRound();
         if (!lastRound || lastRound.ended) {
             if (safe) return;
             throw new Error("No available round to end");
         }
-
-        await lastRound.end({ submission, submitter });
+        await lastRound.end({ winner, stoppage });
     }
 
 

--- a/server/models/round.js
+++ b/server/models/round.js
@@ -136,7 +136,7 @@ class Round extends BaseRecord {
     }
 
 
-    async end({submission, submitter, stoppage, stopper}={}) {
+    async end({winner, stoppage = false}={}) {
         const where = {ended_at: null};
         const ridingTimeVotes = await this.getRidingTimeVotes({ where });
         for (const vote of ridingTimeVotes) {
@@ -146,13 +146,11 @@ class Round extends BaseRecord {
         if (await this.isPaused()) await this.resume();
 
         const match = await this.getMatch();
-        if (submission) {
-            const competitor   = await match.competitorForColor(submitter);
-            this.submission    = submission;
-            this.submission_by = competitor?.id;
-        } else if (stoppage) {
-            const competitor   = await match.competitorForColor(stopper);
-            this.stoppage_by   = competitor?.id;
+
+        if (winner) {
+            const competitor        = await match.competitorForColor(winner);
+            this.declared_winner_id = competitor?.id;
+            this.stoppage           = stoppage;
         }
 
         this.ended_at = new Date();
@@ -160,9 +158,8 @@ class Round extends BaseRecord {
 
         const redScore  = await this.getRedScore();
         const blueScore = await this.getBlueScore();
-        const sub       = submission ? ` submission=${submission} by=${submitter}` : '';
-        const stop      = stoppage   ? ` stoppage by=${stopper}` : '';
-        logger.info(`Round ended: match=${this.match_id} round=${this.id} red=${redScore} blue=${blueScore}${sub}${stop}`);
+        const winLog    = winner ? ` winner=${winner} stoppage=${stoppage}` : '';
+        logger.info(`Round ended: match=${this.match_id} round=${this.id} red=${redScore} blue=${blueScore}${winLog}`);
 
         const allRounds = await match.getRounds();
         logger.info(`Round transition: match=${this.match_id} completedRounds=${allRounds.length} maxRounds=${match.maxRounds}`);
@@ -336,10 +333,6 @@ class Round extends BaseRecord {
 
 Round.initialize();
 
-Round.belongsTo(User, {
-    foreignKey: 'submission_by',
-    as:         'submitter'
-});
 Round.hasMany(RidingTimeVote);
 
 

--- a/server/test/models/round.test.js
+++ b/server/test/models/round.test.js
@@ -308,4 +308,53 @@ describe('round.end()', () => {
         expect(resumeSpy).not.toHaveBeenCalled();
         expect(round.ended_at).toBeInstanceOf(Date);
     });
+
+    it('sets declared_winner_id and stoppage when winner is provided', async () => {
+        const round = makeRound();
+        mockRoundPauseFindAll.mockResolvedValue([closedPause()]);
+
+        const competitorId = 'competitor-red-1';
+        const mockMatch = round.getMatch.mock.results[0]?.value
+            ? await round.getMatch()
+            : null;
+
+        // Re-stub getMatch so competitorForColor returns a competitor with an id
+        round.getMatch = jest.fn().mockResolvedValue({
+            competitorForColor:      jest.fn().mockResolvedValue({ id: competitorId }),
+            getRounds:               jest.fn().mockResolvedValue([round]),
+            getWinner:               jest.fn().mockResolvedValue(null),
+            maxRounds:               999,
+            end:                     jest.fn(),
+            save:                    jest.fn().mockResolvedValue(null),
+            clearCachedAssociation:  jest.fn(),
+            rules:                   { getBreakDuration: jest.fn().mockReturnValue(0) },
+            red_competitor_id:       'red-1',
+            blue_competitor_id:      'blue-1',
+            getJudges:               jest.fn().mockResolvedValue([]),
+            getRedCompetitor:        jest.fn().mockResolvedValue(null),
+            getBlueCompetitor:       jest.fn().mockResolvedValue(null),
+        });
+
+        round.save = jest.fn().mockResolvedValue(round);
+
+        await round.end({ winner: 'red', stoppage: true });
+
+        expect(round.declared_winner_id).toBe(competitorId);
+        expect(round.stoppage).toBe(true);
+        expect(round.ended_at).toBeInstanceOf(Date);
+    });
+
+
+    it('leaves declared_winner_id and stoppage null when winner is not provided', async () => {
+        const round = makeRound();
+        mockRoundPauseFindAll.mockResolvedValue([closedPause()]);
+
+        round.save = jest.fn().mockResolvedValue(round);
+
+        await round.end();
+
+        expect(round.declared_winner_id).toBeUndefined();
+        expect(round.stoppage).toBeUndefined();
+        expect(round.ended_at).toBeInstanceOf(Date);
+    });
 });

--- a/server/test/rules/rDojoKombat.test.js
+++ b/server/test/rules/rDojoKombat.test.js
@@ -1,0 +1,216 @@
+const { RDojoKombatRules } = require('../../lib/rules/rDojoKombat');
+
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+const red  = { id: 'red-competitor-1' };
+const blue = { id: 'blue-competitor-2' };
+
+function endedRound(overrides = {}) {
+    return { ended: true, declared_winner_id: null, stoppage: null, ...overrides };
+}
+
+
+// ===========================================================================
+// techFallThreshold
+// ===========================================================================
+describe('RDojoKombatRules.techFallThreshold', () => {
+    it('returns 24 for round 1', () => {
+        expect(RDojoKombatRules.techFallThreshold(1)).toBe(24);
+    });
+
+    it('returns 16 for round 2', () => {
+        expect(RDojoKombatRules.techFallThreshold(2)).toBe(16);
+    });
+
+    it('returns 8 for round 3', () => {
+        expect(RDojoKombatRules.techFallThreshold(3)).toBe(8);
+    });
+
+    it('returns 8 for rounds beyond 3', () => {
+        expect(RDojoKombatRules.techFallThreshold(4)).toBe(8);
+        expect(RDojoKombatRules.techFallThreshold(10)).toBe(8);
+    });
+});
+
+
+// ===========================================================================
+// getBreakDuration
+// ===========================================================================
+describe('RDojoKombatRules.getBreakDuration', () => {
+    it('returns 60 after round 1', () => {
+        expect(RDojoKombatRules.getBreakDuration(1)).toBe(60);
+    });
+
+    it('returns 60 after round 2', () => {
+        expect(RDojoKombatRules.getBreakDuration(2)).toBe(60);
+    });
+
+    it('returns 0 for out-of-bounds round index (before round 1)', () => {
+        expect(RDojoKombatRules.getBreakDuration(0)).toBe(0);
+    });
+
+    it('returns 0 after round 3 (no break defined)', () => {
+        expect(RDojoKombatRules.getBreakDuration(3)).toBe(0);
+    });
+});
+
+
+// ===========================================================================
+// determineWinner — basic branches
+// ===========================================================================
+describe('RDojoKombatRules.determineWinner — basic branches', () => {
+    it('returns null winner and null method when round has not ended', () => {
+        const round = { ended: false, declared_winner_id: null, stoppage: null };
+        const { winner, method } = RDojoKombatRules.determineWinner(red, blue, 10, 5, 1, round);
+        expect(winner).toBeNull();
+        expect(method.type).toBeNull();
+        expect(method.value).toBeNull();
+    });
+
+    it('returns red as winner with method submission when red has declared_winner_id and stoppage is false', () => {
+        const round = endedRound({ declared_winner_id: red.id, stoppage: false });
+        const { winner, method } = RDojoKombatRules.determineWinner(red, blue, 0, 0, 1, round);
+        expect(winner).toBe(red);
+        expect(method.type).toBe('submission');
+        expect(method.value).toBeNull();
+    });
+
+    it('returns blue as winner with method submission when blue has declared_winner_id and stoppage is false', () => {
+        const round = endedRound({ declared_winner_id: blue.id, stoppage: false });
+        const { winner, method } = RDojoKombatRules.determineWinner(red, blue, 0, 0, 1, round);
+        expect(winner).toBe(blue);
+        expect(method.type).toBe('submission');
+        expect(method.value).toBeNull();
+    });
+
+    it('returns red as winner with method stoppage when declared_winner_id is red and stoppage is true', () => {
+        const round = endedRound({ declared_winner_id: red.id, stoppage: true });
+        const { winner, method } = RDojoKombatRules.determineWinner(red, blue, 0, 0, 1, round);
+        expect(winner).toBe(red);
+        expect(method.type).toBe('stoppage');
+    });
+
+    it('returns points winner when scores differ and no declared_winner_id', () => {
+        const round = endedRound();
+        const { winner, method } = RDojoKombatRules.determineWinner(red, blue, 5, 3, 1, round);
+        expect(winner).toBe(red);
+        expect(method.type).toBe('points');
+        expect(method.value).toBe('5');
+    });
+
+    it('returns tie when scores are equal and no declared_winner_id', () => {
+        const round = endedRound();
+        const { winner, method } = RDojoKombatRules.determineWinner(red, blue, 4, 4, 1, round);
+        expect(winner).toBeNull();
+        expect(method.type).toBe('tie');
+        expect(method.value).toBe('4');
+    });
+});
+
+
+// ===========================================================================
+// determineWinner — edge cases
+// ===========================================================================
+describe('RDojoKombatRules.determineWinner — edge cases', () => {
+    it('scores 20 as points in round 1 (threshold 24) but tech-fall in round 2 (threshold 16)', () => {
+        const round = endedRound();
+
+        const r1 = RDojoKombatRules.determineWinner(red, blue, 20, 0, 1, round);
+        expect(r1.method.type).toBe('points');
+
+        const r2 = RDojoKombatRules.determineWinner(red, blue, 20, 0, 2, round);
+        expect(r2.method.type).toBe('tech-fall');
+    });
+
+    it('score exactly at round-1 threshold (24) is tech-fall, not points', () => {
+        const round = endedRound();
+        const { method } = RDojoKombatRules.determineWinner(red, blue, 24, 0, 1, round);
+        expect(method.type).toBe('tech-fall');
+        expect(method.value).toBe('24');
+    });
+
+    it('score one below round-1 threshold (23) is points, not tech-fall', () => {
+        const round = endedRound();
+        const { method } = RDojoKombatRules.determineWinner(red, blue, 23, 0, 1, round);
+        expect(method.type).toBe('points');
+    });
+
+    it('declared winner takes priority over score — red wins via submission even when blue has a higher score', () => {
+        const round = endedRound({ declared_winner_id: red.id, stoppage: false });
+        const { winner, method } = RDojoKombatRules.determineWinner(red, blue, 0, 50, 1, round);
+        expect(winner).toBe(red);
+        expect(method.type).toBe('submission');
+    });
+
+    it('stoppage method.value is null (not set to score)', () => {
+        const round = endedRound({ declared_winner_id: red.id, stoppage: true });
+        const { method } = RDojoKombatRules.determineWinner(red, blue, 10, 0, 1, round);
+        expect(method.type).toBe('stoppage');
+        expect(method.value).toBeNull();
+    });
+
+    it('techFallThreshold is 8 for any round >= 3', () => {
+        const round = endedRound();
+        // A score of 8 should be tech-fall for rounds 3, 4, and beyond
+        for (const roundNum of [3, 4, 5]) {
+            const { method } = RDojoKombatRules.determineWinner(red, blue, 8, 0, roundNum, round);
+            expect(method.type).toBe('tech-fall');
+        }
+    });
+});
+
+
+// ===========================================================================
+// scoreRound
+// ===========================================================================
+describe('RDojoKombatRules.scoreRound', () => {
+    const judges = [{ id: 'judge-1' }];
+
+    // Helper: call scoreRound with a bound ended_at so open vote periods resolve
+    // to a deterministic timestamp rather than "now"
+    function scoreRound(votes, endedAt) {
+        return RDojoKombatRules.scoreRound.call({ ended_at: endedAt }, red, blue, judges, votes);
+    }
+
+    // Helper: build a completed vote (has an ended_at)
+    function vote(competitorId, startedAt, endedAt) {
+        return { judge_id: 'judge-1', competitor_id: competitorId, started_at: startedAt, ended_at: endedAt };
+    }
+
+    it('floors each period by 3 — 8 seconds of control yields 2 points (not 2.67)', () => {
+        const t0 = new Date('2026-01-01T10:00:00.000Z');
+        const t1 = new Date('2026-01-01T10:00:08.000Z');
+        const votes = [vote(red.id, t0, t1)];
+        const { redScore, blueScore } = scoreRound(votes, t1);
+        expect(redScore).toBe(2);   // floor(8/3) = 2
+        expect(blueScore).toBe(0);
+    });
+
+    it('floors each period independently — two periods of 4s and 5s score 2, not 3', () => {
+        // floor(4/3) + floor(5/3) = 1 + 1 = 2, vs floor(9/3) = 3 if merged
+        const t0 = new Date('2026-01-01T10:00:00.000Z');
+        const t1 = new Date('2026-01-01T10:00:30.000Z');
+        const votes = [
+            vote(red.id, t0,                                    new Date(t0.getTime() +  4000)),
+            vote(red.id, new Date(t0.getTime() + 10000),        new Date(t0.getTime() + 15000)),
+        ];
+        const { redScore } = scoreRound(votes, t1);
+        expect(redScore).toBe(2);
+    });
+
+    it('a control period under 3 seconds contributes zero points', () => {
+        const t0 = new Date('2026-01-01T10:00:00.000Z');
+        const t1 = new Date('2026-01-01T10:00:02.900Z');  // 2.9 s
+        const votes = [vote(red.id, t0, t1)];
+        const { redScore } = scoreRound(votes, t1);
+        expect(redScore).toBe(0);
+    });
+
+    it('returns zero for both competitors when there are no votes', () => {
+        const endedAt = new Date('2026-01-01T10:03:00.000Z');
+        const { redScore, blueScore } = scoreRound([], endedAt);
+        expect(redScore).toBe(0);
+        expect(blueScore).toBe(0);
+    });
+});


### PR DESCRIPTION
## Summary
- Replace `submission` boolean on rounds with `winner` (red/blue/null) and `stoppage` boolean — cleaner model that supports draws and distinguishes submissions from stoppages
- DB migration: `replaceSubmissionWithWinnerOnRounds`
- Update `rDojoKombat` rules and all downstream server/client code
- Add unit tests for `RDojoKombatRules`

## Test plan
- [ ] Run DB migration and verify rounds table schema
- [ ] `npm test` passes (rDojoKombat.test.js, round.test.js)
- [ ] Ending a round via submission records correct winner + stoppage=true
- [ ] Draw round records winner=null

🤖 Generated with [Claude Code](https://claude.com/claude-code)