### PR TITLE
Two-step end round: split end + result into separate API calls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,7 +156,7 @@ Express Route → Controller → Authenticate → Authorize → Execute → Rend
 - `User`: `id`, `name`, `api_token`
 - `Mat`: `id`, `name`, `judge_count`, `creator_id`
 - `Match`: `id`, `mat_id`, `creator_id`, `red_competitor_id`, `blue_competitor_id`, `red_score`, `blue_score`, `started_at`, `ended_at`, `break_started_at`, `break_duration`
-- `Round`: `id`, `match_id`, `ended_at`, `submission`, `submission_by`
+- `Round`: `id`, `match_id`, `ended_at`, `declared_winner_id`, `stoppage`
 - `RidingTimeVote`: `id`, `round_id`, `judge_id`, `competitor_id`, `ended_at`
 - `RoundPause`: `id`, `round_id`, `paused_at`, `resumed_at`
 
@@ -177,15 +177,17 @@ Express Route → Controller → Authenticate → Authorize → Execute → Rend
 
 5. **Room-Based Broadcasting**: WebSocket rooms keep server scalable; all interested clients receive updates atomically
 
-6. **Match Extensions in `models_ext.kt`**: All winner/score derivation from `Match` belongs in `/app/app/src/commonMain/kotlin/dev/jvmname/accord/network/models_ext.kt`, not inlined in presenters. Key extensions: `Match.winner(roundIndex)`, `Match.winnerCompetitor`, `Match.roundScore()`, `Match.toMatchResult()`. `toMatchResult()` always returns a non-null `MatchResult` for any ended match — do NOT add a `winner ?: return null` guard; a null winner on an ended match is a valid draw.
+6. **Match Extensions in `models_ext.kt`**: All winner/score derivation from `Match` belongs in `/app/app/src/commonMain/kotlin/dev/jvmname/accord/network/models_ext.kt`, not inlined in presenters. Key extensions: `Match.winner(roundIndex)`, `Match.winnerCompetitor`, `Match.roundScore()`, `Match.toMatchResult()`. `toMatchResult()` always returns a non-null `MatchResult` for any ended match — do NOT add a `winner ?: return null` guard; a null winner on an ended match is a valid draw. `Match.merge(other)` handles cache updates — some HTTP endpoints return partial payloads (omitting `judges`, `mat`, etc.) and merge preserves cached values for those. `break_remaining` is a worker-computed field that is only present in WebSocket `match.update` payloads — HTTP responses always return it as `null`. `merge` uses `if (breakStartedAt != null) breakRemaining ?: other.breakRemaining else null` to preserve the last WebSocket value during an active break and clear it once the break ends.
 
 7. **`MatchResult` is shared across screens**: Defined in `JudgeSessionScreen.kt` but imported by `MasterSessionScreen.kt` as well. Has `winConditions: String` and `roundWinners: List<Competitor>`. Empty `roundWinners` means all rounds were tied (draw); `toText()` handles this case.
 
 8. **Judge vs Master role separation**: Judges only vote on control time — they do NOT handle meta-round actions (submission, stoppage, manual score edits are master-only). `JudgeSessionEvent.EndRound` is a simple `data object` that ends the round with no params. All structured end-round actions (submission name, who submitted/stopped, stoppage vs submission choice) belong exclusively in the master session.
 
-9. **Master session overlay pattern**: The master uses Circuit's `OverlayEffect` + `BottomSheetOverlay` for dialogs (not `AlertDialog`). The end-round dialog is `SubmissionDialog` in `/app/.../ui/session/master/overlay.kt`, which returns a `SubmissionResult` sealed class. `SubmissionResult.Confirmed` carries both submission and stoppage paths. The content maps the result to `MasterSessionEvent.EndRound` which carries `submission`, `submitter`, `stoppage`, and `stopper` fields.
+9. **Master session overlay pattern**: The master uses Circuit's `OverlayEffect` + `BottomSheetOverlay` for dialogs (not `AlertDialog`). The end-round dialog is `SubmissionDialog` in `/app/.../ui/session/master/overlay.kt`, which returns a `SubmissionResult` sealed class. `SubmissionResult.Confirmed` carries `winner` and `stoppage`. The content maps the result to `MasterSessionEvent.RecordRoundResult(winner, stoppage)` — NOT `EndRound`. `EndRound` is a `data object` that fires `POST /rounds/end` immediately on button tap and opens the dialog; `RecordRoundResult` fires `PATCH /rounds/result` when the dialog is confirmed.
 
-10. **End-round method routing**: `RoundController.endRound(winner, submission, stoppage)` — `winner` doubles as submitter (submission path) or stopper (stoppage path). `MasterSession` routes to the correct `MatchManager.endRound` overload based on the `stoppage` flag. The server API uses `{ submission, submitter }` for submissions and `{ stoppage: true, stopper }` for stoppages.
+10. **All rounds always play out**: A match always runs all `maxRounds` (3) rounds — there is no early exit when a competitor reaches 2 wins. The match winner is determined by best-2-of-3 only after all 3 rounds have completed. `Match.getWinner()` returns `null` while rounds are still in progress. Do not reintroduce early-exit logic in `Round.end()` or `Match.getWinner()`.
+
+11. **Two-step end-round flow**: Ending a round is split into two API calls. `POST /match/:matchId/rounds/end` (no body) stops the clock and starts the break immediately. `PATCH /match/:matchId/rounds/result` `{ winner: "red"|"blue"|null, stoppage: boolean }` records who won — this is only valid during the break or after the match has ended. On the client: `MasterSessionEvent.EndRound` (data object) calls `session.endRound()` and opens the dialog; `MasterSessionEvent.RecordRoundResult(winner, stoppage)` calls `session.recordRoundResult()`. Dismissing the dialog without confirming leaves the result null on the server.
 
 ## Testing
 

--- a/app/app/src/commonJvm/kotlin/dev/jvmname/accord/network/SocketClient.jvm.kt
+++ b/app/app/src/commonJvm/kotlin/dev/jvmname/accord/network/SocketClient.jvm.kt
@@ -3,14 +3,28 @@ package dev.jvmname.accord.network
 import co.touchlab.kermit.Logger
 import dev.jvmname.accord.ui.catchRunning
 import dev.jvmname.accord.ui.onEither
-import dev.zacsweers.metro.*
+import dev.zacsweers.metro.AppScope
+import dev.zacsweers.metro.Assisted
+import dev.zacsweers.metro.AssistedFactory
+import dev.zacsweers.metro.AssistedInject
+import dev.zacsweers.metro.SingleIn
 import io.socket.client.IO
 import io.socket.client.Socket
 import io.socket.emitter.Emitter
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.awaitClose
-import kotlinx.coroutines.flow.*
-import kotlinx.serialization.json.*
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.shareIn
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonNull
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.decodeFromJsonElement
 import org.json.JSONArray
 import org.json.JSONObject
 
@@ -77,7 +91,7 @@ actual class SocketClient actual constructor(
                         json.decodeFromJsonElement<Match>(el)
                     }.onEither(
                         success = { match ->
-                            log.d { "match update matchId=$matchId rounds=${match.rounds.size}" }
+                            log.d { "match update $match" }
                             trySend(match)
                         },
                         failure = { error ->

--- a/app/app/src/commonMain/kotlin/dev/jvmname/accord/domain/Competitor.kt
+++ b/app/app/src/commonMain/kotlin/dev/jvmname/accord/domain/Competitor.kt
@@ -24,8 +24,9 @@ val Competitor.asColor: CompetitorColor
         Competitor.BLUE -> CompetitorColor.BLUE
     }
 
-val Competitor.asEmoji: String
+val Competitor?.asEmoji: String
     get() = when (this) {
         Competitor.RED -> "🟥"
         Competitor.BLUE -> "🟦"
+        null -> "🔲"
     }

--- a/app/app/src/commonMain/kotlin/dev/jvmname/accord/domain/Competitor.kt
+++ b/app/app/src/commonMain/kotlin/dev/jvmname/accord/domain/Competitor.kt
@@ -28,5 +28,5 @@ val Competitor?.asEmoji: String
     get() = when (this) {
         Competitor.RED -> "🟥"
         Competitor.BLUE -> "🟦"
-        null -> "🔲"
+        null -> "⬜"
     }

--- a/app/app/src/commonMain/kotlin/dev/jvmname/accord/domain/MatchManager.kt
+++ b/app/app/src/commonMain/kotlin/dev/jvmname/accord/domain/MatchManager.kt
@@ -137,13 +137,19 @@ class MatchManager(
             }
     }
 
-    suspend fun endRound(
+    suspend fun endRound(matchId: MatchId): NetworkResult<Match> {
+        log.i { "ending round matchId=$matchId" }
+        return client.endRound(matchId)
+            .onOk { match -> updateCache(match) }
+    }
+
+    suspend fun patchRoundResult(
         matchId: MatchId,
         winner: Competitor?,
-        stoppage: Boolean?,
+        stoppage: Boolean,
     ): NetworkResult<Match> {
-        log.i { "ending round matchId=$matchId winner=$winner stoppage=$stoppage" }
-        return client.endRound(matchId, winner = winner?.asColor, stoppage = stoppage ?: false)
+        log.i { "patching round result matchId=$matchId winner=$winner stoppage=$stoppage" }
+        return client.patchRoundResult(matchId, winner = winner?.asColor, stoppage = stoppage)
             .onOk { match ->
                 updateCache(match)
             }

--- a/app/app/src/commonMain/kotlin/dev/jvmname/accord/domain/session/MasterSession.kt
+++ b/app/app/src/commonMain/kotlin/dev/jvmname/accord/domain/session/MasterSession.kt
@@ -111,11 +111,15 @@ class MasterSession(
         scope.launch { matchManager.startRound() }
     }
 
-    override fun endRound(winner: Competitor?, stoppage: Boolean?) {
+    override fun endRound() {
         scope.launch {
-            currentMatchId?.let {
-                matchManager.endRound(it, stoppage = stoppage, winner = winner)
-            }
+            currentMatchId?.let { matchManager.endRound(it) }
+        }
+    }
+
+    fun recordRoundResult(winner: Competitor?, stoppage: Boolean) {
+        scope.launch {
+            currentMatchId?.let { matchManager.patchRoundResult(it, winner, stoppage) }
         }
     }
 

--- a/app/app/src/commonMain/kotlin/dev/jvmname/accord/domain/session/MasterSession.kt
+++ b/app/app/src/commonMain/kotlin/dev/jvmname/accord/domain/session/MasterSession.kt
@@ -29,9 +29,10 @@ import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.runningFold
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.flow.updateAndGet
 import kotlinx.coroutines.launch
 import kotlin.time.Duration
-import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Duration.Companion.milliseconds
 
 @Inject
 @SingleIn(MatchScope::class)
@@ -63,14 +64,15 @@ class MasterSession(
                             log.d { "scores derived red=${it.redPoints} blue=${it.bluePoints}" }
                         }
                     }
-                    val event = deriveRoundEventFromMatch(match).also {
-                        _roundEvent.value = it
+                    val event = _roundEvent.updateAndGet {
+                        deriveRoundEventFromMatch(match, config)
                     }
-                    if (event?.state == RoundEvent.RoundState.STARTED) {
-                        startCountdown(event.remaining)
-                    } else {
-                        countdownJob?.cancel()
-                        countdownJob = null
+                    when (event?.state) {
+                        RoundEvent.RoundState.STARTED -> startCountdown(event)
+                        else -> {
+                            countdownJob?.cancel()
+                            countdownJob = null
+                        }
                     }
                 }
         }
@@ -138,28 +140,23 @@ class MasterSession(
         Logger.d { "manualEdit: API not yet defined — TODO" }
     }
 
-    suspend fun createMatch(matCode: String, red: String, blue: String): NetworkResult<Match> =
-        matchManager.createMatch(matCode, red, blue)
-
     override suspend fun startMatch(): NetworkResult<Match> =
         matchManager.startMatch()
 
     override suspend fun endMatch(): NetworkResult<Match> =
         matchManager.endMatch()
 
-    private fun startCountdown(initialRemaining: Duration) {
+    private fun startCountdown(event: RoundEvent) {
         countdownJob?.cancel()
         countdownJob = scope.launch {
-            var remaining = initialRemaining
+            var remaining = event.remaining
             while (remaining > Duration.ZERO) {
-                delay(1.seconds)
-                remaining -= 1.seconds
+                delay(300.milliseconds)
                 val current = _roundEvent.value ?: return@launch
-                if (current.state == RoundEvent.RoundState.STARTED) {
-                    _roundEvent.value = current.copy(remaining = remaining)
-                } else {
-                    return@launch
-                }
+                if (current.round != event.round || current.roundNumber != event.roundNumber) return@launch
+                if (current.state != RoundEvent.RoundState.STARTED) return@launch
+                remaining -= 300.milliseconds
+                _roundEvent.value = current.copy(remaining = remaining)
             }
         }
     }

--- a/app/app/src/commonMain/kotlin/dev/jvmname/accord/domain/session/MatchSession.kt
+++ b/app/app/src/commonMain/kotlin/dev/jvmname/accord/domain/session/MatchSession.kt
@@ -30,7 +30,7 @@ interface RoundController : PausableSession {
     suspend fun startMatch(): NetworkResult<Match>
     suspend fun endMatch(): NetworkResult<Match>
     fun startRound()
-    fun endRound(winner: Competitor?, stoppage: Boolean?)
+    fun endRound()
     fun manualEdit(competitor: Competitor, action: ManualEditAction)
 }
 

--- a/app/app/src/commonMain/kotlin/dev/jvmname/accord/domain/session/NetworkJudgeSession.kt
+++ b/app/app/src/commonMain/kotlin/dev/jvmname/accord/domain/session/NetworkJudgeSession.kt
@@ -18,10 +18,16 @@ import dev.zacsweers.metro.SingleIn
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.flow.updateAndGet
 import kotlinx.coroutines.launch
 import kotlin.time.Duration
-import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Duration.Companion.milliseconds
 
 @Inject
 @SingleIn(MatchScope::class)
@@ -57,13 +63,15 @@ class NetworkJudgeSession(
                 .collect { match ->
                     currentMatchId = match.id
                     _score.update { deriveScoreFromMatch(match) }
-                    val event = deriveRoundEventFromMatch(match, config)
-                    _roundEvent.value = event
-                    if (event?.state == RoundEvent.RoundState.STARTED) {
-                        startCountdown(event.remaining)
-                    } else {
-                        countdownJob?.cancel()
-                        countdownJob = null
+                    val event = _roundEvent.updateAndGet {
+                        deriveRoundEventFromMatch(match, config)
+                    }
+                    when (event?.state) {
+                        RoundEvent.RoundState.STARTED -> startCountdown(event)
+                        else -> {
+                            countdownJob?.cancel()
+                            countdownJob = null
+                        }
                     }
                 }
         }
@@ -72,7 +80,7 @@ class NetworkJudgeSession(
             buttonPressTracker.buttonEvents.collect { event ->
                 when (event) {
                     is ButtonEvent.Holding -> {
-                        if(activeVote != null) {
+                        if (activeVote != null) {
                             log.d { "button continue held → (no network call) competitor=${event.competitor}" }
                             return@collect
                         }
@@ -80,7 +88,10 @@ class NetworkJudgeSession(
                         scope.launch {
                             log.d { "button started held → startVote competitor=${event.competitor}" }
                             currentMatchId?.let {
-                                matchManager.startRidingTimeVote(it, event.competitor.toCompetitorColor())
+                                matchManager.startRidingTimeVote(
+                                    it,
+                                    event.competitor.toCompetitorColor()
+                                )
                             }
                         }
                     }
@@ -121,19 +132,17 @@ class NetworkJudgeSession(
         scope.launch { currentMatchId?.let { matchManager.resumeRound(it) } }
     }
 
-    private fun startCountdown(initialRemaining: Duration) {
+    private fun startCountdown(event: RoundEvent) {
         countdownJob?.cancel()
         countdownJob = scope.launch {
-            var remaining = initialRemaining
+            var remaining = event.remaining
             while (remaining > Duration.ZERO) {
-                delay(1.seconds)
-                remaining -= 1.seconds
+                delay(300.milliseconds)
                 val current = _roundEvent.value ?: return@launch
-                if (current.state == RoundEvent.RoundState.STARTED) {
-                    _roundEvent.value = current.copy(remaining = remaining)
-                } else {
-                    return@launch
-                }
+                if (current.round != event.round || current.roundNumber != event.roundNumber) return@launch
+                if (current.state != RoundEvent.RoundState.STARTED) return@launch
+                remaining -= 300.milliseconds
+                _roundEvent.value = current.copy(remaining = remaining)
             }
         }
     }

--- a/app/app/src/commonMain/kotlin/dev/jvmname/accord/domain/session/NetworkViewerSession.kt
+++ b/app/app/src/commonMain/kotlin/dev/jvmname/accord/domain/session/NetworkViewerSession.kt
@@ -12,10 +12,15 @@ import dev.zacsweers.metro.SingleIn
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.launch
 import kotlin.time.Duration
-import kotlin.time.Duration.Companion.seconds
+import kotlin.time.Duration.Companion.milliseconds
 
 @Inject
 @SingleIn(MatchScope::class)
@@ -41,7 +46,7 @@ class NetworkViewerSession(
                 val event = deriveRoundEventFromMatch(match)
                 _roundEvent.value = event
                 if (event?.state == RoundEvent.RoundState.STARTED) {
-                    startCountdown(event.remaining)
+                    startCountdown(event)
                 } else {
                     countdownJob?.cancel()
                     countdownJob = null
@@ -50,19 +55,17 @@ class NetworkViewerSession(
         }
     }
 
-    private fun startCountdown(initialRemaining: Duration) {
+    private fun startCountdown(event: RoundEvent) {
         countdownJob?.cancel()
         countdownJob = scope.launch {
-            var remaining = initialRemaining
+            var remaining = event.remaining
             while (remaining > Duration.ZERO) {
-                delay(1.seconds)
-                remaining -= 1.seconds
+                delay(300.milliseconds)
                 val current = _roundEvent.value ?: return@launch
-                if (current.state == RoundEvent.RoundState.STARTED) {
-                    _roundEvent.value = current.copy(remaining = remaining)
-                } else {
-                    return@launch
-                }
+                if (current.round != event.round || current.roundNumber != event.roundNumber) return@launch
+                if (current.state != RoundEvent.RoundState.STARTED) return@launch
+                remaining -= 300.milliseconds
+                _roundEvent.value = current.copy(remaining = remaining)
             }
         }
     }

--- a/app/app/src/commonMain/kotlin/dev/jvmname/accord/domain/session/SoloMatchSession.kt
+++ b/app/app/src/commonMain/kotlin/dev/jvmname/accord/domain/session/SoloMatchSession.kt
@@ -152,7 +152,7 @@ class SoloMatchSession(
                 .drop(1)
                 .collect { (prev, current) ->
                     if (prev == null && current != null) {
-                        endRound(current, null)
+                        endRound()
                     }
                 }
         }
@@ -200,7 +200,7 @@ class SoloMatchSession(
         timer.resume()
     }
 
-    override fun endRound(winner: Competitor?, stoppage: Boolean?) {
+    override fun endRound() {
         timer.cancel()
 
         _roundEvent.update {
@@ -216,7 +216,7 @@ class SoloMatchSession(
     }
 
     override suspend fun endMatch(): NetworkResult<Match> {
-        endRound(null, null)
+        endRound()
         //TODO unclear if this is helpful, maybe Ok(Match)?
         return Err(mapOf("solo" to listOf("no server match in solo mode")))
     }
@@ -252,7 +252,7 @@ class SoloMatchSession(
                 .collect { remaining ->
                     when (remaining) {
                         Duration.ZERO -> {
-                            endRound(null, null)
+                            endRound()
                             startRound()
                         }
 

--- a/app/app/src/commonMain/kotlin/dev/jvmname/accord/network/AccordClient.kt
+++ b/app/app/src/commonMain/kotlin/dev/jvmname/accord/network/AccordClient.kt
@@ -13,6 +13,7 @@ import io.ktor.client.call.body
 import io.ktor.client.request.delete
 import io.ktor.client.request.get
 import io.ktor.client.request.parameter
+import io.ktor.client.request.patch
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import kotlinx.coroutines.Dispatchers
@@ -218,22 +219,36 @@ class AccordClient(private val httpClient: HttpClient) {
         }
     }
 
-    suspend fun endRound(
-        matchId: MatchId,
-        winner: CompetitorColor?,
-        stoppage: Boolean,
-    ): NetworkResult<Match> {
-        log.d { "endRound matchId=$matchId winner=$winner stoppage=$stoppage" }
+    suspend fun endRound(matchId: MatchId): NetworkResult<Match> {
+        log.d { "endRound matchId=$matchId" }
         return withContext(Dispatchers.IO) {
             runSuspendCatching {
-                httpClient.post("match/${matchId.id}/rounds/end") {
-                    setBody(EndRoundRequest(winner = winner, stoppage = stoppage))
-                }.body<ApiResult<MatchResponseData>>()
+                httpClient.post("match/${matchId.id}/rounds/end")
+                    .body<ApiResult<MatchResponseData>>()
             }
                 .unwrapApiResult()
                 .map { it.match }
                 .onOk { log.i { "endRound OK matchId=${it.id}" } }
                 .onErr { log.w { "endRound FAILED: $it" } }
+        }
+    }
+
+    suspend fun patchRoundResult(
+        matchId: MatchId,
+        winner: CompetitorColor?,
+        stoppage: Boolean,
+    ): NetworkResult<Match> {
+        log.d { "patchRoundResult matchId=$matchId winner=$winner stoppage=$stoppage" }
+        return withContext(Dispatchers.IO) {
+            runSuspendCatching {
+                httpClient.patch("match/${matchId.id}/rounds/result") {
+                    setBody(EndRoundRequest(winner = winner, stoppage = stoppage))
+                }.body<ApiResult<MatchResponseData>>()
+            }
+                .unwrapApiResult()
+                .map { it.match }
+                .onOk { log.i { "patchRoundResult OK matchId=${it.id}" } }
+                .onErr { log.w { "patchRoundResult FAILED: $it" } }
         }
     }
 

--- a/app/app/src/commonMain/kotlin/dev/jvmname/accord/network/models_ext.kt
+++ b/app/app/src/commonMain/kotlin/dev/jvmname/accord/network/models_ext.kt
@@ -88,8 +88,8 @@ fun Match.toMatchResult(): MatchResult? {
 //        winnerScore = scores[winnerC] ?: 0,
 //        loserScore = scores[loser] ?: 0,
         winConditions = rounds
-            .filter { it.endedAt != null && it.result.winner == winner && it.result.method.type != null }
+            .filter { it.endedAt != null && it.result.method.type != null }
             .joinToString { it.result.method.type!!.toHumanString },
-        roundWinners = rounds.indices.mapNotNull { winner(it) }
+        roundWinners = rounds.indices.map { winner(it) }
     )
 }

--- a/app/app/src/commonMain/kotlin/dev/jvmname/accord/network/models_ext.kt
+++ b/app/app/src/commonMain/kotlin/dev/jvmname/accord/network/models_ext.kt
@@ -67,6 +67,12 @@ fun Match.merge(other: Match): Match = Match(
     mat = mat ?: other.mat,
     judges = judges.ifEmpty { other.judges },
     rounds = rounds.ifEmpty { other.rounds },
+    breakStartedAt = breakStartedAt,
+    breakDuration = breakDuration,
+    // breakRemaining is computed by the worker and only present in WebSocket updates.
+    // HTTP responses always return null. Preserve the cached value while the break is
+    // still active; clear it once break_started_at is gone (new round started).
+    breakRemaining = if (breakStartedAt != null) breakRemaining ?: other.breakRemaining else null,
 )
 
 val RoundResultType.toHumanString: String

--- a/app/app/src/commonMain/kotlin/dev/jvmname/accord/network/models_ext.kt
+++ b/app/app/src/commonMain/kotlin/dev/jvmname/accord/network/models_ext.kt
@@ -78,15 +78,8 @@ val RoundResultType.toHumanString: String
         RoundResultType.TECH_FALL -> "Techfall"
     }
 
-fun Match.toMatchResult(): MatchResult? {
-    val winner = winner?: return null
-    val winnerC = winnerCompetitor ?: return null
-    val scores = roundScore()
-    val loser = if (winnerC == Competitor.RED) Competitor.BLUE else Competitor.RED
+fun Match.toMatchResult(): MatchResult {
     return MatchResult(
-//        winner = winner to winnerC,
-//        winnerScore = scores[winnerC] ?: 0,
-//        loserScore = scores[loser] ?: 0,
         winConditions = rounds
             .filter { it.endedAt != null && it.result.method.type != null }
             .joinToString { it.result.method.type!!.toHumanString },

--- a/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/session/SessionEvents.kt
+++ b/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/session/SessionEvents.kt
@@ -35,11 +35,11 @@ sealed interface MasterSessionEvent : SessionEvent {
     data object Pause : MasterSessionEvent, PausableEvent
     data object Resume : MasterSessionEvent, PausableEvent
     data object StartRound : MasterSessionEvent, RoundControlEvent
-    data class EndRound(
+    data object EndRound : MasterSessionEvent, RoundControlEvent
+    data class RecordRoundResult(
         val winner: Competitor?,
         val stoppage: Boolean,
     ) : MasterSessionEvent, RoundControlEvent
-    data object ShowEndRoundDialog : MasterSessionEvent
     data object DismissEndRoundDialog : MasterSessionEvent
     data object StartMatch : MasterSessionEvent
     data object EndMatch : MasterSessionEvent

--- a/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/session/judging/JudgeSessionContent.kt
+++ b/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/session/judging/JudgeSessionContent.kt
@@ -3,8 +3,19 @@ package dev.jvmname.accord.ui.session.judging
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.layout.Arrangement.spacedBy
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.HeartBroken
@@ -13,7 +24,16 @@ import androidx.compose.material.icons.filled.Remove
 import androidx.compose.material.icons.outlined.PauseCircle
 import androidx.compose.material.icons.outlined.PlayArrow
 import androidx.compose.material.icons.outlined.Start
-import androidx.compose.material3.*
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.FilledTonalIconButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedIconButton
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
@@ -150,7 +170,7 @@ fun JudgeSessionContent(state: JudgeSessionState, modifier: Modifier) {
                         horizontalAlignment = Alignment.CenterHorizontally,
                         verticalArrangement = spacedBy(16.dp)
                     ) {
-                        Text("Match Over", style = MaterialTheme.typography.headlineMedium,
+                        Text("Match Complete", style = MaterialTheme.typography.headlineMedium,
                             modifier = Modifier.padding(bottom = 16.dp))
 
                         Text(

--- a/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/session/judging/JudgeSessionPresenter.kt
+++ b/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/session/judging/JudgeSessionPresenter.kt
@@ -1,6 +1,10 @@
 package dev.jvmname.accord.ui.session.judging
 
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.produceState
+import androidx.compose.runtime.remember
 import co.touchlab.kermit.Logger
 import com.slack.circuit.codegen.annotations.CircuitInject
 import com.slack.circuit.runtime.Navigator
@@ -102,7 +106,7 @@ class JudgeSessionPresenter(
 
                     JudgeSessionEvent.StartRound -> {
                         (session as? RoundController)?.let { rc ->
-                            rc.endRound(null, null)
+                            rc.endRound()
                             rc.startRound()
                         }
                     }
@@ -111,7 +115,7 @@ class JudgeSessionPresenter(
                     JudgeSessionEvent.Resume -> session.resume()
                     JudgeSessionEvent.Reset -> TODO()
                     JudgeSessionEvent.EndRound -> {
-                        (session as? RoundController)?.endRound(null, null)
+                        (session as? RoundController)?.endRound()
                     }
                 }
             }

--- a/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/session/judging/JudgeSessionScreen.kt
+++ b/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/session/judging/JudgeSessionScreen.kt
@@ -33,7 +33,7 @@ data class MatchResult(
 //    val winnerScore: Int,
 //    val loserScore: Int,
     val winConditions: String,
-    val roundWinners: List<Competitor>,
+    val roundWinners: List<Competitor?>,
 ) {
     fun toText(): String {
         return buildString {

--- a/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/session/judging/JudgeSessionScreen.kt
+++ b/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/session/judging/JudgeSessionScreen.kt
@@ -36,6 +36,7 @@ data class MatchResult(
     val roundWinners: List<Competitor?>,
 ) {
     fun toText(): String {
+        if (roundWinners.isEmpty()) return "🔲 🔲 🔲"
         return buildString {
 //            append("Winner: ", winner.first.name, ' ', winner.second.asEmoji).appendLine()
 //            append("Score: ", winnerScore, " to ", loserScore, "(", winConditions, ")").appendLine()

--- a/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/session/judging/JudgeSessionScreen.kt
+++ b/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/session/judging/JudgeSessionScreen.kt
@@ -36,7 +36,7 @@ data class MatchResult(
     val roundWinners: List<Competitor?>,
 ) {
     fun toText(): String {
-        if (roundWinners.isEmpty()) return "🔲 🔲 🔲"
+        if (roundWinners.isEmpty()) return "⬜ ⬜ ⬜"
         return buildString {
 //            append("Winner: ", winner.first.name, ' ', winner.second.asEmoji).appendLine()
 //            append("Score: ", winnerScore, " to ", loserScore, "(", winConditions, ")").appendLine()

--- a/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/session/master/MasterSessionContent.kt
+++ b/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/session/master/MasterSessionContent.kt
@@ -69,9 +69,9 @@ fun MasterSessionContent(state: MasterSessionState, modifier: Modifier = Modifie
             )
             when (result) {
                 is SubmissionResult.Confirmed -> state.eventSink(
-                    MasterSessionEvent.EndRound(
+                    MasterSessionEvent.RecordRoundResult(
                         winner = result.winner,
-                        stoppage = result.stoppage
+                        stoppage = result.stoppage,
                     )
                 )
 

--- a/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/session/master/MasterSessionPresenter.kt
+++ b/app/app/src/commonMain/kotlin/dev/jvmname/accord/ui/session/master/MasterSessionPresenter.kt
@@ -108,7 +108,6 @@ class MasterSessionPresenter(
             { event ->
                 log.i { "event: $event" }
                 when (event) {
-                    MasterSessionEvent.ShowEndRoundDialog -> showEndRoundDialog = true
                     MasterSessionEvent.DismissEndRoundDialog -> showEndRoundDialog = false
                     MasterSessionEvent.StartMatch -> scope.launch {
                         log.i { "starting match" }
@@ -132,10 +131,16 @@ class MasterSessionPresenter(
                         session.resume()
                     }
 
-                    is MasterSessionEvent.EndRound -> {
-                        log.i { "ending round: submitter=${event.winner?.name} (${event.winner?.color}), stoppage=${event.stoppage}" }
+                    MasterSessionEvent.EndRound -> {
+                        log.i { "ending round" }
+                        session.endRound()
+                        showEndRoundDialog = true
+                    }
+
+                    is MasterSessionEvent.RecordRoundResult -> {
+                        log.i { "recording round result: winner=${event.winner?.name} (${event.winner?.color}), stoppage=${event.stoppage}" }
                         showEndRoundDialog = false
-                        session.endRound(event.winner, event.stoppage)
+                        session.recordRoundResult(event.winner, event.stoppage)
                     }
 
                     MasterSessionEvent.StartRound -> {
@@ -184,7 +189,7 @@ class MasterSessionPresenter(
             onPause = { eventSink(MasterSessionEvent.Pause) },
             onResume = { eventSink(MasterSessionEvent.Resume) },
             onStartRound = { eventSink(MasterSessionEvent.StartRound) },
-            onEndRound = { eventSink(MasterSessionEvent.ShowEndRoundDialog) },
+            onEndRound = { eventSink(MasterSessionEvent.EndRound) },
         )
 
         return MasterSessionState(

--- a/server/controllers/match/roundsController.js
+++ b/server/controllers/match/roundsController.js
@@ -1,4 +1,4 @@
-const { endRoundValidations } = require('../../lib/controllers/roundsControllerHelpers');
+const { isResultWindowOpen } = require('../../lib/controllers/roundsControllerHelpers');
 const { ServerController }    = require('../../lib/server');
 const { logger }              = require('../../lib/logger');
 
@@ -22,13 +22,36 @@ class RoundsController extends ServerController {
 
 
     async postEndRound() {
-        const validations = endRoundValidations.call(this);
+        try {
+            await this.currentMatch.endRound({ safe: false });
+            logger.info(`Round ended: match=${this.currentMatch.id} by user=${this.currentUser.id}`);
+            const options = {includeRounds: true, includeJudges: true, includeMat: true};
+            await this.render({match: this.currentMatch}, options);
+        } catch(err) {
+            await this.renderErrors({matchId: [err.message]});
+        }
+    }
+
+
+    async patchRoundResult() {
+        const validations = { winner: { isEnum: { enums: [undefined, 'red', 'blue'] } } };
         await this.validateParameters(validations);
 
+        if (!isResultWindowOpen(this.currentMatch)) {
+            await this.renderErrors({matchId: ['Round result can only be set during the break or at match end']}, 422);
+            return;
+        }
+
+        const lastRound = await this.currentMatch.getLastRound();
+        if (!lastRound || !lastRound.ended) {
+            await this.renderErrors({matchId: ['No ended round to update']}, 422);
+            return;
+        }
+
         try {
-            await this.currentMatch.endRound(this.params);
+            await lastRound.setResult({ winner: this.params.winner, stoppage: this.params.stoppage });
             const winLog = this.params.winner ? ` winner=${this.params.winner} stoppage=${this.params.stoppage}` : '';
-            logger.info(`Round ended: match=${this.currentMatch.id} by user=${this.currentUser.id}${winLog}`);
+            logger.info(`Round result set: match=${this.currentMatch.id} round=${lastRound.id} by user=${this.currentUser.id}${winLog}`);
 
             const options = {includeRounds: true, includeJudges: true, includeMat: true};
             await this.render({match: this.currentMatch}, options);
@@ -80,10 +103,11 @@ class RoundsController extends ServerController {
 
     static get routes() {
         return {
-          postEndRound:    `/match/:matchId/rounds/end`,
-          postPauseRound:  `/match/:matchId/rounds/pause`,
-          postResumeRound: `/match/:matchId/rounds/resume`,
-          postStartRound:  `/match/:matchId/rounds`
+          patchRoundResult: `/match/:matchId/rounds/result`,
+          postEndRound:     `/match/:matchId/rounds/end`,
+          postPauseRound:   `/match/:matchId/rounds/pause`,
+          postResumeRound:  `/match/:matchId/rounds/resume`,
+          postStartRound:   `/match/:matchId/rounds`
         };
     }
 
@@ -102,16 +126,24 @@ class RoundsController extends ServerController {
                     match: { $ref: 'Match' }
                 }
             },
+            patchRoundResult: {
+                description: 'Record the result of the most recently ended round. Only valid during the break or after the match has ended.',
+                tags: ['match/rounds'],
+                request: {
+                    params: { matchId: { type: 'string', required: true } },
+                    body: {
+                        winner:   { type: 'string', enum: ['red', 'blue'] },
+                        stoppage: { type: 'boolean' }
+                    }
+                },
+                response: { match: { $ref: 'Match' } }
+            },
             postEndRound: {
-                description: 'End the current round for the specified match, optionally recording a winner and whether it was by stoppage.',
+                description: 'End the current round for the specified match.',
                 tags: ['match/rounds'],
                 request: {
                     params: {
                         matchId: { type: 'string', required: true }
-                    },
-                    body: {
-                        winner:   { type: 'string', enum: ['red', 'blue'] },
-                        stoppage: { type: 'boolean' }
                     }
                 },
                 response: {

--- a/server/lib/controllers/roundsControllerHelpers.js
+++ b/server/lib/controllers/roundsControllerHelpers.js
@@ -1,8 +1,8 @@
-function endRoundValidations() {
-    return {
-        winner: { isEnum: { enums: [undefined, 'red', 'blue'] } }
-    };
+function isResultWindowOpen(match) {
+    const breakActive = match.break_started_at != null;
+    const matchEnded  = match.ended_at != null;
+    return breakActive || matchEnded;
 }
 
 
-module.exports = { endRoundValidations };
+module.exports = { isResultWindowOpen };

--- a/server/models/match.js
+++ b/server/models/match.js
@@ -115,13 +115,13 @@ class Match extends BaseRecord {
     }
 
 
-    async endRound({ winner, stoppage, safe }={}) {
+    async endRound({ safe }={}) {
         const lastRound = await this.getLastRound();
         if (!lastRound || lastRound.ended) {
             if (safe) return;
             throw new Error("No available round to end");
         }
-        await lastRound.end({ winner, stoppage });
+        await lastRound.end();
     }
 
 

--- a/server/models/round.js
+++ b/server/models/round.js
@@ -136,7 +136,7 @@ class Round extends BaseRecord {
     }
 
 
-    async end({winner, stoppage = false}={}) {
+    async end() {
         const where = {ended_at: null};
         const ridingTimeVotes = await this.getRidingTimeVotes({ where });
         for (const vote of ridingTimeVotes) {
@@ -147,19 +147,12 @@ class Round extends BaseRecord {
 
         const match = await this.getMatch();
 
-        if (winner) {
-            const competitor        = await match.competitorForColor(winner);
-            this.declared_winner_id = competitor?.id;
-            this.stoppage           = stoppage;
-        }
-
         this.ended_at = new Date();
         await this.save();
 
         const redScore  = await this.getRedScore();
         const blueScore = await this.getBlueScore();
-        const winLog    = winner ? ` winner=${winner} stoppage=${stoppage}` : '';
-        logger.info(`Round ended: match=${this.match_id} round=${this.id} red=${redScore} blue=${blueScore}${winLog}`);
+        logger.info(`Round ended: match=${this.match_id} round=${this.id} red=${redScore} blue=${blueScore}`);
 
         const allRounds = await match.getRounds();
         logger.info(`Round transition: match=${this.match_id} completedRounds=${allRounds.length} maxRounds=${match.maxRounds}`);
@@ -185,6 +178,23 @@ class Round extends BaseRecord {
                 }
             }
         }
+    }
+
+
+    async setResult({ winner, stoppage = false } = {}) {
+        if (!this.ended) throw new Error('Cannot set result on a round that has not ended');
+
+        if (winner) {
+            const match             = await this.getMatch();
+            const competitor        = await match.competitorForColor(winner);
+            this.declared_winner_id = competitor?.id;
+            this.stoppage           = stoppage;
+        } else {
+            this.declared_winner_id = null;
+            this.stoppage           = null;
+        }
+
+        await this.save();
     }
 
 

--- a/server/test/models/round.test.js
+++ b/server/test/models/round.test.js
@@ -309,38 +309,14 @@ describe('round.end()', () => {
         expect(round.ended_at).toBeInstanceOf(Date);
     });
 
-    it('sets declared_winner_id and stoppage when winner is provided', async () => {
+    it('sets ended_at when end() is called', async () => {
         const round = makeRound();
         mockRoundPauseFindAll.mockResolvedValue([closedPause()]);
 
-        const competitorId = 'competitor-red-1';
-        const mockMatch = round.getMatch.mock.results[0]?.value
-            ? await round.getMatch()
-            : null;
-
-        // Re-stub getMatch so competitorForColor returns a competitor with an id
-        round.getMatch = jest.fn().mockResolvedValue({
-            competitorForColor:      jest.fn().mockResolvedValue({ id: competitorId }),
-            getRounds:               jest.fn().mockResolvedValue([round]),
-            getWinner:               jest.fn().mockResolvedValue(null),
-            maxRounds:               999,
-            end:                     jest.fn(),
-            save:                    jest.fn().mockResolvedValue(null),
-            clearCachedAssociation:  jest.fn(),
-            rules:                   { getBreakDuration: jest.fn().mockReturnValue(0) },
-            red_competitor_id:       'red-1',
-            blue_competitor_id:      'blue-1',
-            getJudges:               jest.fn().mockResolvedValue([]),
-            getRedCompetitor:        jest.fn().mockResolvedValue(null),
-            getBlueCompetitor:       jest.fn().mockResolvedValue(null),
-        });
-
         round.save = jest.fn().mockResolvedValue(round);
 
-        await round.end({ winner: 'red', stoppage: true });
+        await round.end();
 
-        expect(round.declared_winner_id).toBe(competitorId);
-        expect(round.stoppage).toBe(true);
         expect(round.ended_at).toBeInstanceOf(Date);
     });
 
@@ -356,5 +332,203 @@ describe('round.end()', () => {
         expect(round.declared_winner_id).toBeUndefined();
         expect(round.stoppage).toBeUndefined();
         expect(round.ended_at).toBeInstanceOf(Date);
+    });
+});
+
+
+// ===========================================================================
+// round.end() — match transition (all 3 rounds always run)
+// ===========================================================================
+describe('round.end() — match transition', () => {
+    function makeRoundWithMatch(matchOverrides = {}) {
+        const round = makeRound();
+        mockRoundPauseFindAll.mockResolvedValue([]);
+        round.save = jest.fn().mockResolvedValue(round);
+
+        const matchDefaults = {
+            competitorForColor:      jest.fn(),
+            getRounds:               jest.fn().mockResolvedValue([round]),
+            getWinner:               jest.fn().mockResolvedValue(null),
+            maxRounds:               3,
+            end:                     jest.fn(),
+            save:                    jest.fn().mockResolvedValue(null),
+            clearCachedAssociation:  jest.fn(),
+            rules:                   { getBreakDuration: jest.fn().mockReturnValue(0) },
+            red_competitor_id:       'red-1',
+            blue_competitor_id:      'blue-1',
+            getJudges:               jest.fn().mockResolvedValue([]),
+            getRedCompetitor:        jest.fn().mockResolvedValue(null),
+            getBlueCompetitor:       jest.fn().mockResolvedValue(null),
+        };
+        round.getMatch = jest.fn().mockResolvedValue({ ...matchDefaults, ...matchOverrides });
+        return round;
+    }
+
+    it('ends the match after the 3rd round (max-rounds-reached)', async () => {
+        const round1 = makeRound();
+        const round2 = makeRound();
+        const round3 = makeRound();
+        const endMock = jest.fn();
+        round3.getMatch = jest.fn().mockResolvedValue({
+            competitorForColor:      jest.fn(),
+            getRounds:               jest.fn().mockResolvedValue([round1, round2, round3]),
+            maxRounds:               3,
+            end:                     endMock,
+            save:                    jest.fn().mockResolvedValue(null),
+            clearCachedAssociation:  jest.fn(),
+            rules:                   { getBreakDuration: jest.fn().mockReturnValue(0) },
+            red_competitor_id:       'red-1',
+            blue_competitor_id:      'blue-1',
+            getJudges:               jest.fn().mockResolvedValue([]),
+            getRedCompetitor:        jest.fn().mockResolvedValue(null),
+            getBlueCompetitor:       jest.fn().mockResolvedValue(null),
+        });
+        mockRoundPauseFindAll.mockResolvedValue([]);
+        round3.save = jest.fn().mockResolvedValue(round3);
+
+        await round3.end();
+
+        expect(endMock).toHaveBeenCalled();
+    });
+
+    it('does NOT end the match after round 1 even if one competitor has won', async () => {
+        const round1 = makeRound();
+        const endMock = jest.fn();
+        round1.getMatch = jest.fn().mockResolvedValue({
+            competitorForColor:      jest.fn(),
+            getRounds:               jest.fn().mockResolvedValue([round1]),
+            getWinner:               jest.fn().mockResolvedValue({ id: 'red-competitor' }),
+            maxRounds:               3,
+            end:                     endMock,
+            save:                    jest.fn().mockResolvedValue(null),
+            clearCachedAssociation:  jest.fn(),
+            rules:                   { getBreakDuration: jest.fn().mockReturnValue(60) },
+            red_competitor_id:       'red-1',
+            blue_competitor_id:      'blue-1',
+            getJudges:               jest.fn().mockResolvedValue([]),
+            getRedCompetitor:        jest.fn().mockResolvedValue(null),
+            getBlueCompetitor:       jest.fn().mockResolvedValue(null),
+        });
+        mockRoundPauseFindAll.mockResolvedValue([]);
+        round1.save = jest.fn().mockResolvedValue(round1);
+
+        await round1.end();
+
+        expect(endMock).not.toHaveBeenCalled();
+    });
+
+    it('does NOT end the match after round 2 even if one competitor has won twice', async () => {
+        const round1 = makeRound();
+        const round2 = makeRound();
+        const endMock = jest.fn();
+        round2.getMatch = jest.fn().mockResolvedValue({
+            competitorForColor:      jest.fn(),
+            getRounds:               jest.fn().mockResolvedValue([round1, round2]),
+            getWinner:               jest.fn().mockResolvedValue({ id: 'red-competitor' }),
+            maxRounds:               3,
+            end:                     endMock,
+            save:                    jest.fn().mockResolvedValue(null),
+            clearCachedAssociation:  jest.fn(),
+            rules:                   { getBreakDuration: jest.fn().mockReturnValue(60) },
+            red_competitor_id:       'red-1',
+            blue_competitor_id:      'blue-1',
+            getJudges:               jest.fn().mockResolvedValue([]),
+            getRedCompetitor:        jest.fn().mockResolvedValue(null),
+            getBlueCompetitor:       jest.fn().mockResolvedValue(null),
+        });
+        mockRoundPauseFindAll.mockResolvedValue([]);
+        round2.save = jest.fn().mockResolvedValue(round2);
+
+        await round2.end();
+
+        expect(endMock).not.toHaveBeenCalled();
+    });
+
+    it('starts a break after round 1 (not the final round)', async () => {
+        const round1 = makeRound();
+        const matchSave = jest.fn().mockResolvedValue(null);
+        const breakDurationFn = jest.fn().mockReturnValue(60);
+        round1.getMatch = jest.fn().mockResolvedValue({
+            competitorForColor:      jest.fn(),
+            getRounds:               jest.fn().mockResolvedValue([round1]),
+            maxRounds:               3,
+            end:                     jest.fn(),
+            save:                    matchSave,
+            clearCachedAssociation:  jest.fn(),
+            rules:                   { getBreakDuration: breakDurationFn },
+            red_competitor_id:       'red-1',
+            blue_competitor_id:      'blue-1',
+            getJudges:               jest.fn().mockResolvedValue([]),
+            getRedCompetitor:        jest.fn().mockResolvedValue(null),
+            getBlueCompetitor:       jest.fn().mockResolvedValue(null),
+        });
+        mockRoundPauseFindAll.mockResolvedValue([]);
+        round1.save = jest.fn().mockResolvedValue(round1);
+
+        await round1.end();
+
+        const match = await round1.getMatch();
+        expect(match.break_duration).toBe(60);
+        expect(match.break_started_at).toBeInstanceOf(Date);
+        expect(matchSave).toHaveBeenCalled();
+    });
+});
+
+
+// ===========================================================================
+// round.setResult()
+// ===========================================================================
+describe('round.setResult()', () => {
+    it('throws if the round has not ended', async () => {
+        const round = makeRound();  // makeRound returns a round with no ended_at
+        await expect(round.setResult({ winner: 'red', stoppage: false })).rejects.toThrow('Cannot set result on a round that has not ended');
+    });
+
+    it('sets declared_winner_id and stoppage when winner is provided', async () => {
+        const competitorId = 'competitor-1';
+        const round = makeRound();
+        round.ended_at = new Date();
+
+        // mock getMatch to return a match that resolves competitorForColor
+        round.getMatch = jest.fn().mockResolvedValue({
+            competitorForColor: jest.fn().mockResolvedValue({ id: competitorId }),
+        });
+        round.save = jest.fn().mockResolvedValue(round);
+
+        await round.setResult({ winner: 'red', stoppage: true });
+
+        expect(round.declared_winner_id).toBe(competitorId);
+        expect(round.stoppage).toBe(true);
+    });
+
+    it('clears declared_winner_id and stoppage to null when no winner is provided', async () => {
+        const round = makeRound();
+        round.ended_at = new Date();
+        round.declared_winner_id = 'some-id';
+        round.stoppage = true;
+        round.save = jest.fn().mockResolvedValue(round);
+
+        await round.setResult();
+
+        expect(round.declared_winner_id).toBeNull();
+        expect(round.stoppage).toBeNull();
+    });
+
+    it('is idempotent — calling setResult again overwrites the previous result', async () => {
+        const competitorId = 'competitor-2';
+        const round = makeRound();
+        round.ended_at = new Date();
+        round.declared_winner_id = 'old-id';
+        round.stoppage = false;
+
+        round.getMatch = jest.fn().mockResolvedValue({
+            competitorForColor: jest.fn().mockResolvedValue({ id: competitorId }),
+        });
+        round.save = jest.fn().mockResolvedValue(round);
+
+        await round.setResult({ winner: 'blue', stoppage: true });
+
+        expect(round.declared_winner_id).toBe(competitorId);
+        expect(round.stoppage).toBe(true);
     });
 });


### PR DESCRIPTION
## Summary
- `POST /rounds/end` stops the clock and starts the break immediately (no winner params)
- `PATCH /rounds/result` records `winner` + `stoppage` — valid during break or after match ends
- Client: `MasterSessionEvent.EndRound` calls `endRound()` and opens the dialog; `MasterSessionEvent.RecordRoundResult(winner, stoppage)` calls `recordRoundResult()` on confirm
- `JudgeSessionEvent.EndRound` is now a simple `data object` with no params

**Stacked on #47** (simplify-submissions) — merge that first.

## Test plan
- [ ] End a round — verify clock stops and break starts immediately
- [ ] Confirm submission dialog — verify winner + stoppage recorded correctly
- [ ] Dismiss dialog without confirming — verify result stays null on server
- [ ] round.test.js passes (`setResult` suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)