### PR TITLE
Bug fixes and polish

### DIFF
--- a/app/shared/src/androidMain/kotlin/dev/jvmname/accord/ui/theme/Theme.android.kt
+++ b/app/shared/src/androidMain/kotlin/dev/jvmname/accord/ui/theme/Theme.android.kt
@@ -5,7 +5,11 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.ProvidedValue
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalInspectionMode
+import dev.jvmname.accord.di.LocalPlatformContext
 
 @Composable
 actual fun AccordTheme(
@@ -23,9 +27,21 @@ actual fun AccordTheme(
         else -> lightScheme
     }
 
-    MaterialTheme(
-        colorScheme = colorScheme,
-        typography = AccordTypography,
-        content = content
-    )
+    val clps = if (LocalInspectionMode.current) {
+        arrayOf(
+            LocalPlatformContext provides LocalContext.current
+        )
+
+    } else {
+        emptyArray<ProvidedValue<*>>()
+
+    }
+    CompositionLocalProvider(*clps) {
+        MaterialTheme(
+            colorScheme = colorScheme,
+            typography = AccordTypography,
+            content = content
+        )
+    }
+
 }

--- a/app/shared/src/commonMain/kotlin/dev/jvmname/accord/ui/common/CompetitorEditText.kt
+++ b/app/shared/src/commonMain/kotlin/dev/jvmname/accord/ui/common/CompetitorEditText.kt
@@ -33,13 +33,13 @@ fun CompetitorEditText(
         label = { Text("${competitor.nameStr} Competitor") },
         placeholder = { Text("Competitor name") },
         isError = isError,
-        supportingText = if (isError) { { Text("Required") } } else null,
+        supportingText = if (isError) { @Composable { Text("Required") } } else null,
         lineLimits = TextFieldLineLimits.SingleLine,
         keyboardOptions = KeyboardOptions.Default.copy(
             capitalization = KeyboardCapitalization.Words,
             imeAction = imeAction,
         ),
-        onKeyboardAction = { onKeyboardAction?.invoke() },
+        onKeyboardAction = { default -> onKeyboardAction?.invoke() ?: default() },
         colors = OutlinedTextFieldDefaults.colors(
             focusedBorderColor = focusedBorder,
             unfocusedBorderColor = unfocusedBorder,

--- a/app/shared/src/commonMain/kotlin/dev/jvmname/accord/ui/showcodes/ShowCodesPresenter.kt
+++ b/app/shared/src/commonMain/kotlin/dev/jvmname/accord/ui/showcodes/ShowCodesPresenter.kt
@@ -19,6 +19,7 @@ import dev.zacsweers.metro.Assisted
 import dev.zacsweers.metro.AssistedFactory
 import dev.zacsweers.metro.AssistedInject
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import kotlin.time.Duration.Companion.seconds
 
 @AssistedInject
@@ -32,7 +33,7 @@ class ShowCodesPresenter(
     override fun present(): ShowCodesState {
         val joinedJudges by produceState(emptyList(), key1 = screen) {
             val adminCode = screen.mat.adminCode.code
-            while (true) {
+            while (coroutineContext.isActive) {
                 matManager.listJudges(adminCode).onOk { value = it }
                 delay(1.5.seconds)
             }

--- a/app/shared/src/jvmMain/kotlin/dev/jvmname/accord/ui/theme/Theme.jvm.kt
+++ b/app/shared/src/jvmMain/kotlin/dev/jvmname/accord/ui/theme/Theme.jvm.kt
@@ -2,6 +2,11 @@ package dev.jvmname.accord.ui.theme
 
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.ProvidedValue
+import androidx.compose.ui.platform.LocalInspectionMode
+import dev.jvmname.accord.di.EmptyPlatformContext
+import dev.jvmname.accord.di.LocalPlatformContext
 
 @Composable
 actual fun AccordTheme(
@@ -15,6 +20,20 @@ actual fun AccordTheme(
             else -> lightScheme
         }
 
-    // No custom fonts available in Desktop
-    MaterialTheme(colorScheme = colorScheme, content = content)
+    val clps = if (LocalInspectionMode.current) {
+        arrayOf(
+            LocalPlatformContext provides EmptyPlatformContext
+        )
+
+    } else {
+        emptyArray<ProvidedValue<*>>()
+
+    }
+    CompositionLocalProvider(*clps) {
+        MaterialTheme(
+            colorScheme = colorScheme,
+            typography = AccordTypography,
+            content = content
+        )
+    }
 }


### PR DESCRIPTION
## Summary
- Fix keyboard navigation in `CompetitorEditText` (focus/action key handling)
- Stop polling in `ShowCodesPresenter` after navigating away from the screen
- Fix compose previews in `Theme.android.kt` and `Theme.jvm.kt`

## Test plan
- [ ] Tab/enter key navigation works correctly in competitor name fields
- [ ] Navigating away from the show-codes screen stops any background polling
- [ ] Android Studio previews render without crashing